### PR TITLE
Ensure Context.getFileDocument reaches the desired path

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage.kt
@@ -130,10 +130,24 @@ fun Context.getFileDocument(path: String): DocumentFile? {
 
     var document = DocumentFile.fromTreeUri(this, Uri.parse(baseConfig.treeUri))
     val parts = relativePath.split("/")
-    for (part in parts) {
-        val currDocument = document.findFile(part)
-        if (currDocument != null)
-            document = currDocument
+    for (i in 0..parts.size - 1) {
+        var currDocument = document.findFile(parts[i])
+        if (currDocument == null) {
+            // We need to assure that we transverse to the right directory!
+            if (i == parts.size - 1) {
+                // The last document should be the file we're looking for, not a directory
+                currDocument = document.createFile("", parts[i])
+            } else {
+                currDocument = document.createDirectory(parts[i])
+            }
+
+            if (currDocument == null) {
+                // Half paths should not be tolerated. If the given path cannot
+                // be accessed, give up with an Exception to let the caller know.
+                throw UnsupportedOperationException("Failed to reach $path.")
+            }
+        }
+        document = currDocument
     }
     return document
 }


### PR DESCRIPTION
Currently `Context.getFileDocument` may not reach the specified path. Say for instance the `/some/example.txt` file is trying to be accessed. But the directory `some/` doesn't exist, but `example.txt` does. Then, this file (`example.txt`) will be chosen instead the desired `/some/example.txt`, which may cause obscure data loss.

This fix ensures that the right path is chosen, even if it has to create it.