### PR TITLE
confirm_otg_storage_access_text+1

### DIFF
--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -264,8 +264,8 @@
 
     <!-- OTG devices -->
     <string name="otg">OTG</string>
-    <string name="confirm_otg_storage_access_text">Please choose the root folder of the OTG device on the next screen, to grant access</string>
-    <string name="wrong_root_selected_otg">Wrong folder selected, please select the root folder of your OTG device</string>
+    <string name="confirm_otg_storage_access_text">Vælg rodmappen på \'OTG\'-enheden på den næste skærm for at give adgang.</string>
+    <string name="wrong_root_selected_otg">Den forkerte mappe er valgt, vælg rodmappen på din \'OTG\'-enhed</string>
 
     <!-- About -->
     <string name="about">Om</string>


### PR DESCRIPTION
I have not translated 'OTG' though I do not believe that it is a common known acronym, at least not among Danes in general. I do not know it myself. Acronymfinder.com suggests: On-The-Go (USB 2.0 specification), On the Ground (sales) and Off the Ground (gaming) - are you talking about USB2? Maybe I could have omitted the term 'OTG' and just translate 'device' - or will it make sense for those who need to grant access to the root directory?