### PR TITLE
faq_4 title & text

### DIFF
--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -305,8 +305,8 @@
         Du kan finde en guide på siden https://github.com/SimpleMobileTools/General-Discussion, eller send mig en besked på hello@simplemobiletools.com hvis du har brug for hjælp.</string>
     <string name="faq_3_title_commons">Jeg fik slettet nogle filer ved en fejl, hvordan kan jeg gendanne dem?</string>
     <string name="faq_3_text_commons">Det kan du desværre ikke. Filer er væk så snart sletningen er bekræftet, og der er ingen papirkurv.</string>
-    <string name="faq_4_title_commons">I don\'t like the widget colors, can I change them?</string>
-    <string name="faq_4_text_commons">Yep, as you drag a widget on your home screen a widget config screen appears. You will see colored squares at the bottom left corner, just press them to pick a new color. You can use the slider for adjusting the alpha too.</string>
+    <string name="faq_4_title_commons">Jeg bryder mig ikke om farverne på widget'en, kan jeg ændre dem?</string>
+    <string name="faq_4_text_commons">Jep. Når du trækker en widget på din skærm kommer muligheden for at konfigurere den frem. I nederste venstre hjørne finder du farvede kvadrater, klik på dem og vælg en ny farve. Du kan justere alfa med skyderen.</string>
 
     <!-- License -->
     <string name="notice">Denne app bruger følgende 3.-parts biblioteker der gør at mit liv bliver lidt enklere. Tak.</string>


### PR DESCRIPTION
Have you updated how it works in future versions? Here is how it works on my phone:

When you add a widget to your home screen from the widget list on your device the colour configuration options appears. You will see a square at the bottom left corner, just press it to pick a new colour. You can use the slider for adjusting the alpha too.
The option to resize it appears if you drag the widget on the screen.