### PR TITLE
Fix typo in 'saving' string

### DIFF
--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -70,7 +70,7 @@
     <string name="moving_success_partial">Niektóre pliki nie mogą być przeniesione</string>
     <string name="copying_success_partial">Niektóre pliki nie mogą być skopiowane</string>
     <string name="no_files_selected">Nie wybrano żadnych plików</string>
-    <string name="saving">Zapsisuję…</string>
+    <string name="saving">Zapisuję…</string>
     <string name="could_not_create_folder">Nie mogę utworzyć folderu %s</string>
     <string name="could_not_create_file">Nie mogę utworzyć pliku %s</string>
 


### PR DESCRIPTION
Follow up from email.
Will be keeping an eye for more typos and untranslated strings when I have time