### PR TITLE
moving_items_into_bin

### DIFF
--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -409,8 +409,8 @@
     <string name="recycle_bin_empty">Papirkurven er tom</string>
 
     <plurals name="moving_items_into_bin">
-        <item quantity="one">Moving %d item into the Recycle Bin</item>
-        <item quantity="other">Moving %d items into the Recycle Bin</item>
+        <item quantity="one">Flytter %d fil til papirkurven</item>
+        <item quantity="other">Flytter %d filer til papirkurven</item>
     </plurals>
 
     <!-- Import / Export -->


### PR DESCRIPTION
Why do you use a variable for 'one'? Why not just write 'one' or '1'? I guess that the variable will be replaced by '1', so it is not a problem, just an unnecessary complication. 
If you in other strings use a variable for the word 'one', the translation to Danish could end up being wrong, we have two versions of the word, 'en' and 'et'.