### PR TITLE
delete_warning

### DIFF
--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -232,7 +232,7 @@
     <string name="no">Nej</string>
 
     <plurals name="delete_warning">
-        <item quantity="one">ADVARSEL: Du sletter %d mappe</item>
+        <item quantity="one">ADVARSEL: Du sletter en mappe</item>
         <item quantity="other">ADVARSEL: Du sletter %d mapper</item>
     </plurals>
 


### PR DESCRIPTION
In this case I suggest not to change the string. It does not look so good if the variable will be replaced by a number, and I do not know which version of the Danish 'one' will be used if it is replaced by a word. Actually I now regret I didn't suggest the same for <item quantity="one">Moving %d item into the Recycle Bin</item>, 'Flytter en fil til papirkurven'