### PR TITLE
adding option keep both in conflicts dialog 

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -257,13 +257,14 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                             val updatedFiles = ArrayList<FileDirItem>(fileDirItems.size * 2)
                             val destinationFolder = File(destination)
                             for (oldFileDirItem in fileDirItems) {
-                                val newFile = File(destinationFolder, oldFileDirItem.name)
+                                var newFile = File(destinationFolder, oldFileDirItem.name)
                                 if (newFile.exists()) {
-                                    if (getConflictResolution(it, newFile.absolutePath) == CONFLICT_SKIP) {
-                                        fileCountToCopy--
-                                    } else {
-                                        // this file is guaranteed to be on the internal storage, so just delete it this way
-                                        newFile.delete()
+                                    when {
+                                        getConflictResolution(it, newFile.absolutePath) == CONFLICT_SKIP -> fileCountToCopy--
+                                        getConflictResolution(it, newFile.absolutePath) == CONFLICT_KEEP_BOTH -> newFile = getAlternativeFile(newFile)
+                                        else ->
+                                            // this file is guaranteed to be on the internal storage, so just delete it this way
+                                            newFile.delete()
                                     }
                                 }
 
@@ -292,6 +293,17 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                 }
             }
         }
+    }
+
+    fun getAlternativeFile(file: File): File {
+        var fileIndex = 1
+        var newFile: File?
+        do {
+            val newName = String.format("%s(%d).%s", file.nameWithoutExtension, fileIndex, file.extension)
+            newFile = File(file.parent, newName)
+            fileIndex++
+        } while (newFile!!.exists())
+        return newFile
     }
 
     private fun startCopyMove(files: ArrayList<FileDirItem>, destinationPath: String, isCopyOperation: Boolean, copyPhotoVideoOnly: Boolean, copyHidden: Boolean) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/asynctasks/CopyMoveTask.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/asynctasks/CopyMoveTask.kt
@@ -80,7 +80,7 @@ class CopyMoveTask(val activity: BaseSimpleActivity, val copyOnly: Boolean = fal
         for (file in mFiles) {
             try {
                 val newPath = "$mDestinationPath/${file.name}"
-                val newFileDirItem = FileDirItem(newPath, newPath.getFilenameFromPath(), file.isDirectory)
+                var newFileDirItem = FileDirItem(newPath, newPath.getFilenameFromPath(), file.isDirectory)
                 if (activity.getDoesFilePathExist(newPath)) {
                     val resolution = getConflictResolution(conflictResolutions, newPath)
                     if (resolution == CONFLICT_SKIP) {
@@ -89,6 +89,9 @@ class CopyMoveTask(val activity: BaseSimpleActivity, val copyOnly: Boolean = fal
                     } else if (resolution == CONFLICT_OVERWRITE) {
                         newFileDirItem.isDirectory = if (File(newPath).exists()) File(newPath).isDirectory else activity.getSomeDocumentFile(newPath)!!.isDirectory
                         activity.deleteFileBg(newFileDirItem, true)
+                    } else if (resolution == CONFLICT_KEEP_BOTH) {
+                        val newFile = activity.getAlternativeFile(File(newFileDirItem.path))
+                        newFileDirItem = FileDirItem(newFile.path, newFile.name, newFile.isDirectory)
                     }
                 }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FileConflictDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FileConflictDialog.kt
@@ -3,11 +3,11 @@ package com.simplemobiletools.commons.dialogs
 import android.app.Activity
 import androidx.appcompat.app.AlertDialog
 import com.simplemobiletools.commons.R
-import com.simplemobiletools.commons.R.id.conflict_dialog_radio_merge
-import com.simplemobiletools.commons.R.id.conflict_dialog_radio_skip
+import com.simplemobiletools.commons.R.id.*
 import com.simplemobiletools.commons.extensions.baseConfig
 import com.simplemobiletools.commons.extensions.beVisibleIf
 import com.simplemobiletools.commons.extensions.setupDialogStuff
+import com.simplemobiletools.commons.helpers.CONFLICT_KEEP_BOTH
 import com.simplemobiletools.commons.helpers.CONFLICT_MERGE
 import com.simplemobiletools.commons.helpers.CONFLICT_OVERWRITE
 import com.simplemobiletools.commons.helpers.CONFLICT_SKIP
@@ -44,6 +44,7 @@ class FileConflictDialog(val activity: Activity, val fileDirItem: FileDirItem, v
         val resolution = when (view.conflict_dialog_radio_group.checkedRadioButtonId) {
             conflict_dialog_radio_skip -> CONFLICT_SKIP
             conflict_dialog_radio_merge -> CONFLICT_MERGE
+            conflict_dialog_radio_keep_both -> CONFLICT_KEEP_BOTH
             else -> CONFLICT_OVERWRITE
         }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -175,6 +175,7 @@ const val PERMISSION_GET_ACCOUNTS = 12
 const val CONFLICT_SKIP = 1
 const val CONFLICT_OVERWRITE = 2
 const val CONFLICT_MERGE = 3
+const val CONFLICT_KEEP_BOTH = 4
 
 const val MONDAY_BIT = 1
 const val TUESDAY_BIT = 2

--- a/commons/src/main/res/layout/dialog_file_conflict.xml
+++ b/commons/src/main/res/layout/dialog_file_conflict.xml
@@ -50,6 +50,13 @@
             android:paddingBottom="@dimen/normal_margin"
             android:paddingTop="@dimen/normal_margin"
             android:text="@string/merge"/>
+        <com.simplemobiletools.commons.views.MyCompatRadioButton
+            android:id="@+id/conflict_dialog_radio_keep_both"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="@dimen/normal_margin"
+            android:paddingTop="@dimen/normal_margin"
+            android:text="@string/keep_both"/>
 
     </RadioGroup>
 

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overwrite</string>
     <string name="skip">Skip</string>
     <string name="append">Append with \'_1\'</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">\"%s\" faylı artıq mövcuddur. Üzərinə yazılsın?</string>
     <string name="folder_already_exists">\"%s\" qovluğu artıq mövcuddur</string>
     <string name="merge">Birləşdir</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Üzərinə yaz</string>
     <string name="skip">Keç</string>
     <string name="append">\'_1\' ilə əlavə et</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overwrite</string>
     <string name="skip">Skip</string>
     <string name="append">Append with \'_1\'</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">L’arxiu \"%s\" ja existeix. El vos sobreescriure?</string>
     <string name="folder_already_exists">La carpeta \"%s\" ja existeix</string>
     <string name="merge">Fusionar</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Sobreescriure</string>
     <string name="skip">Saltar</string>
     <string name="append">Afegir \'_1\'</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Soubor \"%s\" již existuje. Přepsat?</string>
     <string name="folder_already_exists">Složka \"%s\" již existuje</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Přepsat</string>
     <string name="skip">Přeskočit</string>
     <string name="append">Ponechat s \'_1\'</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Filen \"%s\" findes allerede. Overskriv?</string>
     <string name="folder_already_exists">Mappen \"%s\" findes allerede</string>
     <string name="merge">Sammenflet</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overskriv</string>
     <string name="skip">Spring over</string>
     <string name="append">Tilføj \"_1\"</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Datei \"%s\" existiert bereits. Überschreiben?</string>
     <string name="folder_already_exists">Ordner \"%s\" existiert bereits</string>
     <string name="merge">Zusammenführen</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Überschreiben</string>
     <string name="skip">Überspringen</string>
     <string name="append">\'_1\' anhängen</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Το αρχείο \"%s\" υπάρχει ήδη. Αντικατάσταση?</string>
     <string name="folder_already_exists">Ο φάκελος \"%s\" υπάρχει ήδη</string>
     <string name="merge">Συγχώνευση</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Αντικατάσταση</string>
     <string name="skip">Παράβλεψη</string>
     <string name="append">Προσάρτηση με \'_1\'</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">El archivo \"%s\" ya existe. Sobreescribir?</string>
     <string name="folder_already_exists">La carpeta \"%s\" ya existe</string>
     <string name="merge">Fusionar</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Sobreescribir</string>
     <string name="skip">Saltar</string>
     <string name="append">Añadir \'_1\'</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Tiedosto \"%s\" on jo olemassa. Korvataanko?</string>
     <string name="folder_already_exists">Kansio \"%s\" on jo olemassa</string>
     <string name="merge">Yhdistä</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Korvaa</string>
     <string name="skip">Ohita</string>
     <string name="append">Lisää nimeen \'_1\'</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Le fichier \"%s\" existe déjà. Écraser ?</string>
     <string name="folder_already_exists">Le répertoire \"%s\" existe déjà</string>
     <string name="merge">Fusionner</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Écraser</string>
     <string name="skip">Passer</string>
     <string name="append">Ajouter un suffixe \"_1\"</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">El archivo \"%s\" ya existe. Sobreescribir?</string>
     <string name="folder_already_exists">La carpeta \"%s\" ya existe</string>
     <string name="merge">Fusionar</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Sobreescribir</string>
     <string name="skip">Saltar</string>
     <string name="append">Añadir \'_1\'</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overwrite</string>
     <string name="skip">Skip</string>
     <string name="append">Append with \'_1\'</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Datoteka \"%s\" već postoji. Presnimiti?</string>
     <string name="folder_already_exists">Mapa \"%s\" već postoji</string>
     <string name="merge">Spoji</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Presnimi</string>
     <string name="skip">Preskoči</string>
     <string name="append">Dodaj s \'_1\'</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">\"%s\" fájl már létezik. Felülírja?</string>
     <string name="folder_already_exists"> \"%s\" mappa már létezik</string>
     <string name="merge">Összevonás</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Felülírás</string>
     <string name="skip">Átlépés</string>
     <string name="append">Mellékel \'_1\'</string>

--- a/commons/src/main/res/values-id/strings.xml
+++ b/commons/src/main/res/values-id/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" Sudah Ada. Timpa saja?</string>
     <string name="folder_already_exists">Folder \"%s\" Sudah Ada</string>
     <string name="merge">Gabung</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Timpa</string>
     <string name="skip">Lewati</string>
     <string name="append">Tambahkan Dengan \'_1\'</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Il file \"%s\" esiste già. Sovrascrivi?</string>
     <string name="folder_already_exists">La cartella \"%s\" esiste già</string>
     <string name="merge">Unisci</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Sovrascrivi</string>
     <string name="skip">Salta</string>
     <string name="append">Aggiungi \'_1\' alla fine</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overwrite</string>
     <string name="skip">Skip</string>
     <string name="append">Append with \'_1\'</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">ファイル \"%s\" は既に存在しています。上書きしますか？</string>
     <string name="folder_already_exists">フォルダ \"%s\" は既に存在しています</string>
     <string name="merge">統合</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">上書き</string>
     <string name="skip">スキップ</string>
     <string name="append">\'_1\' に追記する</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">\"%s\" 파일이 이미 존재합니다. 덮어쓰시겠습니까?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">덮어쓰기</string>
     <string name="skip">건너뛰기</string>
     <string name="append">\'_1\' 문자열을 추가함</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Byla \"%s\" jau yra. Pervadinti?</string>
     <string name="folder_already_exists">Aplankalas \"%ai\" jau yra</string>
     <string name="merge">Sulieti</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Užrašyti ant viršaus</string>
     <string name="skip">Praleisti</string>
     <string name="append">Papildyti su \'_1\'</string>

--- a/commons/src/main/res/values-nb/strings.xml
+++ b/commons/src/main/res/values-nb/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Filen \"%s\" finnes allerede. Overskrive?</string>
     <string name="folder_already_exists">Mappen \"%s\" finnes allerede</string>
     <string name="merge">Sammenslå</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overskriv</string>
     <string name="skip">Hopp over</string>
     <string name="append">Tilføy \'_1\'</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Bestand \"%s\" bestaat reeds. Overschrijven?</string>
     <string name="folder_already_exists">Map \"%s\" bestaat reeds</string>
     <string name="merge">Samenvoegen</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overschrijven</string>
     <string name="skip">Overslaan</string>
     <string name="append">Voeg \'_1\' toe</string>

--- a/commons/src/main/res/values-no/strings.xml
+++ b/commons/src/main/res/values-no/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overskriv</string>
     <string name="skip">Hopp over</string>
     <string name="append">Append with \'_1\'</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Plik \"%s\" już istnieje. Nadpisać?</string>
     <string name="folder_already_exists">Folder \"%s\" już istnieje</string>
     <string name="merge">Połącz</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Nadpisz</string>
     <string name="skip">Pomiń</string>
     <string name="append">Dodaj końcówkę \'_1\'</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Já existe um arquivo com o nome \"%s\". Substituir?</string>
     <string name="folder_already_exists">A pasta \"%s\" já existe</string>
     <string name="merge">Mesclar</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Substituir</string>
     <string name="skip">Ignorar</string>
     <string name="append">Adicionar sufixo \'_1\'</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Já existe um ficheiro com o nome \"%s\". Substituir?</string>
     <string name="folder_already_exists">Já existe uma pasta com o nome \"%s\"</string>
     <string name="merge">Unir</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Substituir</string>
     <string name="skip">Ignorar</string>
     <string name="append">Anexar \'_1\'</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Файл \"%s\" уже существует. Перезаписать?</string>
     <string name="folder_already_exists">Папка \"%s\" уже существует</string>
     <string name="merge">Объединить</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Перезаписать</string>
     <string name="skip">Пропустить</string>
     <string name="append">Добавить \"_1\" к имени</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Súbor \"%s\" už existuje. Prepísať?</string>
     <string name="folder_already_exists">Priečinok \"%s\" už existuje</string>
     <string name="merge">Zlúčiť</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Prepísať</string>
     <string name="skip">Preskočiť</string>
     <string name="append">Pripnúť \'_1\'</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Datoteka %s že obstaja. Jo želite prepisati?</string>
     <string name="folder_already_exists">Mapa %s že obstaja</string>
     <string name="merge">Združi</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Prepiši</string>
     <string name="skip">Preskoči</string>
     <string name="append">Dodaj \'_1\'</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">Filen \"%s\" finns redan. Skriv över?</string>
     <string name="folder_already_exists">Mappen \"%s\" finns redan</string>
     <string name="merge">Slå ihop</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Skriv över</string>
     <string name="skip">Hoppa över</string>
     <string name="append">Lägg till \'_1\'</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">\"%s\" dosyası zaten var. Üzerine yazılsın mı?</string>
     <string name="folder_already_exists">\"%s\" klasörü zaten var</string>
     <string name="merge">Birleştir</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Üzerine yaz</string>
     <string name="skip">Atla</string>
     <string name="append">\'_1\' ile ekle</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">文件 \"%s\" 已存在。是否覆盖？</string>
     <string name="folder_already_exists">文件夹 \"%s\" 已存在</string>
     <string name="merge">合并</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">覆盖</string>
     <string name="skip">跳过</string>
     <string name="append">应用到 \'_1\'</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">檔案 \"%s\" 已經存在。 要覆蓋嗎?</string>
     <string name="folder_already_exists">資料夾 \"%s\" 已經存在</string>
     <string name="merge">合併</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">覆蓋</string>
     <string name="skip">跳過</string>
     <string name="append">附加 \'_1\'</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="file_already_exists_overwrite">File \"%s\" already exists. Overwrite?</string>
     <string name="folder_already_exists">Folder \"%s\" already exists</string>
     <string name="merge">Merge</string>
+    <string name="keep_both">Keep both</string>
     <string name="overwrite">Overwrite</string>
     <string name="skip">Skip</string>
     <string name="append">Append with \'_1\'</string>


### PR DESCRIPTION
Creating feature based on issue https://github.com/SimpleMobileTools/Simple-Gallery/issues/818. Adding option "keep both" to the conflict dialog that will keep both files(e.g. image.png, image(1).png)