### PR TITLE
Update nl string.xml

### DIFF
--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -544,13 +544,13 @@
     <string name="in_november">in november</string>
     <string name="in_december">in december</string>
 
-    <string name="monday">Maandag</string>
-    <string name="tuesday">Dinsdag</string>
-    <string name="wednesday">Woensdag</string>
-    <string name="thursday">Donderdag</string>
-    <string name="friday">Vrijdag</string>
-    <string name="saturday">Zaterdag</string>
-    <string name="sunday">Zondag</string>
+    <string name="monday">maandag</string>
+    <string name="tuesday">dinsdag</string>
+    <string name="wednesday">woensdag</string>
+    <string name="thursday">donderdag</string>
+    <string name="friday">vrijdag</string>
+    <string name="saturday">zaterdag</string>
+    <string name="sunday">zondag</string>
 
     <string name="monday_letter">M</string>
     <string name="tuesday_letter">D</string>
@@ -560,13 +560,13 @@
     <string name="saturday_letter">Z</string>
     <string name="sunday_letter">Z</string>
 
-    <string name="monday_short">Maa</string>
-    <string name="tuesday_short">Din</string>
-    <string name="wednesday_short">Woe</string>
-    <string name="thursday_short">Don</string>
-    <string name="friday_short">Vri</string>
-    <string name="saturday_short">Zat</string>
-    <string name="sunday_short">Zon</string>
+    <string name="monday_short">ma</string>
+    <string name="tuesday_short">di</string>
+    <string name="wednesday_short">wo</string>
+    <string name="thursday_short">do</string>
+    <string name="friday_short">vr</string>
+    <string name="saturday_short">za</string>
+    <string name="sunday_short">zo</string>
 
     <!-- Pro version -->
     <string name="upgrade_to_pro_long">Deze app zal niet langer worden bijgewerkt. Upgrade naar de Pro-versie om gebruik te kunnen maken van nieuwe functies en verbeteringen.</string>


### PR DESCRIPTION
Made more in style of official spelling of Dutch language. (days of the week are written with small letter in Dutch, shorten form is with 2 letters). The letter "ij" in vrijdag is one symbol and cannot be splitted.

This should make the clock widget more in style of the "official" android clock widget in Dutch version.


left the "official" clock, right the SMT clock widget as it is now:
![klok](https://user-images.githubusercontent.com/25467829/74746229-62bdc580-5265-11ea-8cbf-279b7a1759b1.jpg)

If other files has to be changed to get the wished result, please let me know.

See also my comment here: [https://github.com/SimpleMobileTools/Simple-Commons/pull/859#issuecomment-585962239](url)

