### PR TITLE
Dutch (months and days_short)

### DIFF
--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -517,18 +517,18 @@
     <string name="wrong_root_selected_usb">Verkeerde map geselecteerd, kies de hoofdmap van het USB-apparaat</string>
 
     <!-- Dates -->
-    <string name="january">januari</string>
-    <string name="february">februari</string>
-    <string name="march">maart</string>
-    <string name="april">april</string>
-    <string name="may">mei</string>
-    <string name="june">juni</string>
-    <string name="july">juli</string>
-    <string name="august">augustus</string>
-    <string name="september">september</string>
-    <string name="october">oktober</string>
-    <string name="november">november</string>
-    <string name="december">december</string>
+    <string name="january">Januari</string>
+    <string name="february">Februari</string>
+    <string name="march">Maart</string>
+    <string name="april">April</string>
+    <string name="may">Mei</string>
+    <string name="june">Juni</string>
+    <string name="july">Juli</string>
+    <string name="august">Augustus</string>
+    <string name="september">September</string>
+    <string name="october">Oktober</string>
+    <string name="november">November</string>
+    <string name="december">December</string>
 
     <!-- in January -->
     <string name="in_january">in januari</string>
@@ -560,13 +560,13 @@
     <string name="saturday_letter">Z</string>
     <string name="sunday_letter">Z</string>
 
-    <string name="monday_short">Maa</string>
-    <string name="tuesday_short">Din</string>
-    <string name="wednesday_short">Woe</string>
-    <string name="thursday_short">Don</string>
-    <string name="friday_short">Vri</string>
-    <string name="saturday_short">Zat</string>
-    <string name="sunday_short">Zon</string>
+    <string name="monday_short">Ma</string>
+    <string name="tuesday_short">Di</string>
+    <string name="wednesday_short">Wo</string>
+    <string name="thursday_short">Do</string>
+    <string name="friday_short">Vr</string>
+    <string name="saturday_short">Za</string>
+    <string name="sunday_short">Zo</string>
 
     <!-- Pro version -->
     <string name="upgrade_to_pro_long">Deze app zal niet langer worden bijgewerkt. Upgrade naar de Pro-versie om gebruik te kunnen maken van nieuwe functies en verbeteringen.</string>


### PR DESCRIPTION
1. Revert changed case for month names not in sentences (from previous commit by @Joppla)
2. Change short day format to 2 characters (as by @Joppla in https://github.com/SimpleMobileTools/Simple-Commons/pull/860, while keeping upper case first letter)