### PR TITLE
updated ChangeDateTimeFormatDialog (for Simple-Calendar)

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
@@ -2,6 +2,7 @@ package com.simplemobiletools.commons.dialogs
 
 import android.app.Activity
 import android.text.format.DateFormat
+import android.view.View
 import androidx.appcompat.app.AlertDialog
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.R.id.*
@@ -11,7 +12,7 @@ import com.simplemobiletools.commons.helpers.*
 import kotlinx.android.synthetic.main.dialog_change_date_time_format.view.*
 import java.util.*
 
-class ChangeDateTimeFormatDialog(val activity: Activity, val callback: () -> Unit) {
+class ChangeDateTimeFormatDialog(val activity: Activity, val datesOnly: Boolean = false, val callback: () -> Unit) {
     val view = activity.layoutInflater.inflate(R.layout.dialog_change_date_time_format, null)!!
     val sampleTS = 1557964800000    // May 16, 2019
 
@@ -25,7 +26,9 @@ class ChangeDateTimeFormatDialog(val activity: Activity, val callback: () -> Uni
             change_date_time_dialog_radio_six.text = formatDateSample(DATE_FORMAT_SIX)
             change_date_time_dialog_radio_seven.text = formatDateSample(DATE_FORMAT_SEVEN)
             change_date_time_dialog_radio_eight.text = formatDateSample(DATE_FORMAT_EIGHT)
+            change_date_time_dialog_radio_nine.text = formatDateSample(DATE_FORMAT_NINE)
 
+            change_date_time_dialog_24_hour.visibility = if (datesOnly) View.INVISIBLE else View.VISIBLE
             change_date_time_dialog_24_hour.isChecked = activity.baseConfig.use24HourFormat
 
             val formatButton = when (activity.baseConfig.dateFormat) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
@@ -14,6 +14,7 @@ import java.util.*
 
 class ChangeDateTimeFormatDialog(val activity: Activity, val datesOnly: Boolean = false, val callback: () -> Unit) {
     val view = activity.layoutInflater.inflate(R.layout.dialog_change_date_time_format, null)!!
+    val sampleTS = 1557964800000    // May 16, 2019
 
     init {
         view.apply {
@@ -68,8 +69,8 @@ class ChangeDateTimeFormatDialog(val activity: Activity, val datesOnly: Boolean 
     }
 
     private fun formatDateSample(format: String): String {
-        val cal = Calendar.getInstance().time
+        val cal = Calendar.getInstance(Locale.ENGLISH)
+        cal.timeInMillis = sampleTS
         return DateFormat.format(format, cal).toString()
-
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ChangeDateTimeFormatDialog.kt
@@ -14,7 +14,6 @@ import java.util.*
 
 class ChangeDateTimeFormatDialog(val activity: Activity, val datesOnly: Boolean = false, val callback: () -> Unit) {
     val view = activity.layoutInflater.inflate(R.layout.dialog_change_date_time_format, null)!!
-    val sampleTS = 1557964800000    // May 16, 2019
 
     init {
         view.apply {
@@ -69,8 +68,8 @@ class ChangeDateTimeFormatDialog(val activity: Activity, val datesOnly: Boolean 
     }
 
     private fun formatDateSample(format: String): String {
-        val cal = Calendar.getInstance(Locale.ENGLISH)
-        cal.timeInMillis = sampleTS
+        val cal = Calendar.getInstance().time
         return DateFormat.format(format, cal).toString()
+
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -273,6 +273,7 @@ const val DATE_FORMAT_FIVE = "d MMMM yyyy"
 const val DATE_FORMAT_SIX = "MMMM d yyyy"
 const val DATE_FORMAT_SEVEN = "MM-dd-yyyy"
 const val DATE_FORMAT_EIGHT = "dd-MM-yyyy"
+const val DATE_FORMAT_NINE = "dd. MMMM yyyy"
 
 const val TIME_FORMAT_12 = "hh:mm a"
 const val TIME_FORMAT_24 = "HH:mm"

--- a/commons/src/main/res/layout/dialog_change_date_time_format.xml
+++ b/commons/src/main/res/layout/dialog_change_date_time_format.xml
@@ -84,6 +84,14 @@
             android:paddingBottom="@dimen/normal_margin"
             tools:text="MMMM d yyyy" />
 
+        <com.simplemobiletools.commons.views.MyCompatRadioButton
+            android:id="@+id/change_date_time_dialog_radio_nine"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/normal_margin"
+            android:paddingBottom="@dimen/normal_margin"
+            tools:text="dd. MMMM yyyy" />
+
     </RadioGroup>
 
     <com.simplemobiletools.commons.views.MyAppCompatCheckbox


### PR DESCRIPTION
preparation for using this dialog in Simple-Calendar
* added new date format dd. MMMM yyyy (common in Germany)
* added parameter to hide 24h clock checkmark (for date format only)
