### PR TITLE
change primary color of black theme

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/CustomizationActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/CustomizationActivity.kt
@@ -127,7 +127,7 @@ class CustomizationActivity : BaseSimpleActivity() {
             put(THEME_DARK, MyTheme(R.string.dark_theme, R.color.theme_dark_text_color, R.color.theme_dark_background_color, R.color.color_primary, R.color.color_primary))
             //put(THEME_SOLARIZED, MyTheme(R.string.solarized, R.color.theme_solarized_text_color, R.color.theme_solarized_background_color, R.color.theme_solarized_primary_color))
             put(THEME_DARK_RED, MyTheme(R.string.dark_red, R.color.theme_dark_text_color, R.color.theme_dark_background_color, R.color.theme_dark_red_primary_color, R.color.md_red_700))
-            put(THEME_BLACK_WHITE, MyTheme(R.string.black_white, android.R.color.white, android.R.color.black, android.R.color.black, R.color.md_grey_black))
+            put(THEME_BLACK_WHITE, MyTheme(R.string.black_white, android.R.color.white, android.R.color.black, R.color.color_primary_dark, R.color.md_grey_black))
             put(THEME_CUSTOM, MyTheme(R.string.custom, 0, 0, 0, 0))
 
             if (storedSharedTheme != null) {


### PR DESCRIPTION
Changed the primary color from black to the dark primary color.
The primary color is used for several labels in the settings and the apps.
Therefore these texts are not visible (black on black) with the default color setting for the black and white theme.

As the theme is not black and white anymore, I suggest to rename the black and white theme to black. This is also the usual denotation for the black background theme.

Of cause changing the primary color to white will also work, but will result in a less visual structured appearance of the apps.