### PR TITLE
Allow custom keypad to digits converter without breaking apps

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -209,9 +209,9 @@ fun String.getNameLetter() = normalizeString().toCharArray().getOrNull(0)?.toStr
 
 fun String.normalizePhoneNumber() = PhoneNumberUtils.normalizeNumber(this)
 
-fun String.highlightTextFromNumbers(textToHighlight: String, adjustedPrimaryColor: Int): SpannableString {
+fun String.highlightTextFromNumbers(textToHighlight: String, adjustedPrimaryColor: Int, converter: (String) -> String = PhoneNumberUtils::convertKeypadLettersToDigits): SpannableString {
     val spannableString = SpannableString(this)
-    val digits = PhoneNumberUtils.convertKeypadLettersToDigits(this)
+    val digits = converter(this)
     if (digits.contains(textToHighlight)) {
         val startIndex = digits.indexOf(textToHighlight, 0, true)
         val endIndex = Math.min(startIndex + textToHighlight.length, length)


### PR DESCRIPTION
Android `PhoneNumberUtils` builtin `convertKeypadLettersToDigits` converter doesn't handle well languages different then English. This patch allows sending different converters to the `highlightTextFromNumbers` extension method.  