### PR TITLE
Optimize loading thumbnails

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerItemsAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerItemsAdapter.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade
 import com.bumptech.glide.request.RequestOptions
 import com.simplemobiletools.commons.R
@@ -86,6 +87,7 @@ class FilepickerItemsAdapter(activity: BaseSimpleActivity, val fileDirItems: Lis
                 val path = fileDirItem.path
                 val placeholder = fileDrawables.getOrElse(fileDirItem.name.substringAfterLast(".").toLowerCase(Locale.getDefault()), { fileDrawable })
                 val options = RequestOptions()
+                        .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                         .centerCrop()
                         .error(placeholder)
 


### PR DESCRIPTION
[<img src="https://user-images.githubusercontent.com/5478075/94331026-b9446c80-ffc9-11ea-94b6-17eda0b812b0.png" width="1024">_(click to maximize image)_](https://user-images.githubusercontent.com/5478075/94331026-b9446c80-ffc9-11ea-94b6-17eda0b812b0.png)

I found a bottleneck in your app. [FilepickerItemsAdapter.kt](
https://github.com/SimpleMobileTools/Simple-Commons/blob/master/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FilePickerDialog.kt) didn't use cached thumbnails and don't create a new cache. I fixed this in this MR. At the top is measuring the value of a metric generating new thumbnails ① and load cached thumbnails ②.