### PR TITLE
Fix Renaming of multiple files

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
@@ -25,7 +25,7 @@ class RenameSimpleTab(context: Context, attrs: AttributeSet) : RelativeLayout(co
     }
 
     override fun dialogConfirmed(useMediaFileExtension: Boolean, callback: (success: Boolean) -> Unit) {
-        val valueToAdd = rename_simple_value.value
+        val valueToAdd = rename_simple_value.text.toString()
         val append = rename_simple_radio_group.checkedRadioButtonId == rename_simple_radio_append.id
 
         if (valueToAdd.isEmpty()) {


### PR DESCRIPTION
Renaming of directory was working fine as .value of the EditText was changed to .text.toString() but it was still there in RenameSimpleTab.kt