### PR TITLE
Switch to AndroidX's ExifInterface.

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.1'
     implementation 'androidx.documentfile:documentfile:1.0.1'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     api 'androidx.appcompat:appcompat:1.2.0'

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/PropertiesDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/PropertiesDialog.kt
@@ -2,7 +2,6 @@ package com.simplemobiletools.commons.dialogs
 
 import android.app.Activity
 import android.content.res.Resources
-import android.media.ExifInterface
 import android.net.Uri
 import android.provider.MediaStore
 import android.view.LayoutInflater
@@ -10,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.exifinterface.media.ExifInterface
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.*

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -12,7 +12,6 @@ import android.content.res.Configuration
 import android.database.Cursor
 import android.graphics.Color
 import android.graphics.Point
-import android.media.ExifInterface
 import android.media.MediaMetadataRetriever
 import android.media.RingtoneManager
 import android.net.Uri
@@ -34,6 +33,7 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.exifinterface.media.ExifInterface
 import androidx.loader.content.CursorLoader
 import com.github.ajalt.reprint.core.Reprint
 import com.google.gson.Gson

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/ExifInterface.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/ExifInterface.kt
@@ -1,15 +1,13 @@
 package com.simplemobiletools.commons.extensions
 
-import android.annotation.TargetApi
 import android.content.Context
-import android.media.ExifInterface
-import android.os.Build
+import androidx.exifinterface.media.ExifInterface
 import java.text.SimpleDateFormat
 import java.util.*
 
 fun ExifInterface.copyTo(destination: ExifInterface, copyOrientation: Boolean = true) {
     val attributes = arrayListOf(
-            ExifInterface.TAG_APERTURE,
+            ExifInterface.TAG_F_NUMBER, // Replaces TAG_APERTURE
             ExifInterface.TAG_DATETIME,
             ExifInterface.TAG_DATETIME_DIGITIZED,
             ExifInterface.TAG_DATETIME_ORIGINAL,
@@ -27,7 +25,7 @@ fun ExifInterface.copyTo(destination: ExifInterface, copyOrientation: Boolean = 
             ExifInterface.TAG_GPS_TIMESTAMP,
             ExifInterface.TAG_IMAGE_LENGTH,
             ExifInterface.TAG_IMAGE_WIDTH,
-            ExifInterface.TAG_ISO_SPEED_RATINGS,
+            ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY, // Replaces TAG_ISO_SPEED_RATINGS
             ExifInterface.TAG_MAKE,
             ExifInterface.TAG_MODEL,
             ExifInterface.TAG_WHITE_BALANCE)
@@ -49,7 +47,6 @@ fun ExifInterface.copyTo(destination: ExifInterface, copyOrientation: Boolean = 
     }
 }
 
-@TargetApi(Build.VERSION_CODES.N)
 fun ExifInterface.getExifProperties(): String {
     var exifString = ""
     getAttribute(ExifInterface.TAG_F_NUMBER).let {
@@ -78,7 +75,7 @@ fun ExifInterface.getExifProperties(): String {
         }
     }
 
-    getAttribute(ExifInterface.TAG_ISO_SPEED_RATINGS).let {
+    getAttribute(ExifInterface.TAG_PHOTOGRAPHIC_SENSITIVITY).let {
         if (it?.isNotEmpty() == true) {
             exifString += "ISO-$it"
         }
@@ -87,7 +84,6 @@ fun ExifInterface.getExifProperties(): String {
     return exifString.trim()
 }
 
-@TargetApi(Build.VERSION_CODES.N)
 fun ExifInterface.getExifDateTaken(context: Context): String {
     val dateTime = getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL) ?: getAttribute(ExifInterface.TAG_DATETIME)
     dateTime.let {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Int.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Int.kt
@@ -3,10 +3,10 @@ package com.simplemobiletools.commons.extensions
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.media.ExifInterface
 import android.text.format.DateFormat
 import android.text.format.DateUtils
 import android.text.format.Time
+import androidx.exifinterface.media.ExifInterface
 import java.text.DecimalFormat
 import java.util.*
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
@@ -1,14 +1,13 @@
 package com.simplemobiletools.commons.views
 
 import android.content.Context
-import android.media.ExifInterface
 import android.text.format.DateFormat
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.exifinterface.media.ExifInterface
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.*
-import com.simplemobiletools.commons.helpers.isNougatPlus
 import com.simplemobiletools.commons.interfaces.RenameTab
 import kotlinx.android.synthetic.main.dialog_rename_items_pattern.view.*
 import java.io.File
@@ -62,12 +61,8 @@ class RenamePatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(c
             val numbersCnt = pathsCnt.toString().length
             for (path in validPaths) {
                 val exif = ExifInterface(path)
-                var dateTime = if (isNougatPlus()) {
-                    exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)
+                var dateTime = exif.getAttribute(ExifInterface.TAG_DATETIME_ORIGINAL)
                         ?: exif.getAttribute(ExifInterface.TAG_DATETIME)
-                } else {
-                    exif.getAttribute(ExifInterface.TAG_DATETIME)
-                }
 
                 if (dateTime == null) {
                     val calendar = Calendar.getInstance(Locale.ENGLISH)


### PR DESCRIPTION
The documentation for the framework [`ExifInterface`](https://developer.android.com/reference/android/media/ExifInterface) class recommends switching to AndroidX's class, as it is a superset of the framework class and includes additional functionality.