### PR TITLE
Dutch

### DIFF
--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -485,7 +485,7 @@
     <string name="your_sounds">Eigen geluiden</string>
     <string name="add_new_sound">Nieuw geluid toevoegen</string>
     <string name="no_sound">Geen geluid</string>
-    <string name="during_day_at_hh_mm">Overdag om hh.mmu</string>
+    <string name="during_day_at_hh_mm">Overdag om uu:mm</string>
     <string name="during_day_at">Overdag om %02d.%02du</string>
 
     <!-- Settings -->

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -485,8 +485,8 @@
     <string name="your_sounds">Eigen geluiden</string>
     <string name="add_new_sound">Nieuw geluid toevoegen</string>
     <string name="no_sound">Geen geluid</string>
-    <string name="during_day_at_hh_mm">During the day at hh:mm</string>
-    <string name="during_day_at">During the day at %02d:%02d</string>
+    <string name="during_day_at_hh_mm">Overdag om hh.mmu</string>
+    <string name="during_day_at">Overdag om %02d.%02du</string>
 
     <!-- Settings -->
     <string name="settings">Instellingen</string>


### PR DESCRIPTION
**QUESTION!**

- "during_day_at": I'm assuming that %02d:%02d is replaced with the actual hours and minutes, but:
- "during_day_at_hh_mm": Do `hh` and `mm` get replaced, or is this just a regular string?
