### PR TITLE
Correct translation for 'start_name_with_surname'

### DIFF
--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -526,7 +526,7 @@
     <string name="import_settings">Importa impostazioni</string>
     <string name="settings_exported_successfully">Impostazioni esportate correttamente</string>
     <string name="settings_imported_successfully">Impostazioni importate correttamente</string>
-    <string name="start_name_with_surname">Prima il nome poi il cognome</string>
+    <string name="start_name_with_surname">Prima il cognome poi il nome</string>
     <string name="clear_cache">Clear cache</string>
 
     <!-- Setting sections -->


### PR DESCRIPTION
The current translation makes the apps behave the other way round (sorting for surname when user chooses to sort by name).