### PR TITLE
Minor fixes in Spanish strings

### DIFF
--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -504,7 +504,7 @@
     <string name="customize_colors_locked">Cambiar colores (Locked)</string>
     <string name="customize_widget_colors">Personaliza los colores del widget</string>
     <string name="customize_notifications">Customize notifications</string>
-    <string name="use_english_language">Usar el idioma Inglés</string>
+    <string name="use_english_language">Usar el idioma inglés</string>
     <string name="show_hidden_items">Mostrar elementos ocultos</string>
     <string name="font_size">Tamaño de fuente</string>
     <string name="small">Pequeña</string>
@@ -543,7 +543,7 @@
     <string name="scrolling">Desplazamiento</string>
     <string name="file_operations">Operaciones con ficheros</string>
     <string name="recycle_bin">Papelera de reciclaje</string>
-    <string name="saving_label">Guardando</string>
+    <string name="saving_label">Guardado</string>
     <string name="startup">Puesta en marcha</string>
     <string name="text">Texto</string>
     <string name="migrating">Migrando</string>


### PR DESCRIPTION
This assumes that the `saving_label` is always used as a header section for saving related settings rather than some indication that something is actually saving. By the way, if this is really the case, I think many of the translations are making similar conjugation errors with these settings headers.