### PR TITLE
Fixed nonclickable links in FAQ

### DIFF
--- a/commons/src/main/res/layout/license_faq_item.xml
+++ b/commons/src/main/res/layout/license_faq_item.xml
@@ -16,6 +16,7 @@
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/license_faq_text"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content"
+        android:autoLink="email|web" />
 
 </LinearLayout>


### PR DESCRIPTION
Hi,

I've found out that in the FAQ section all links and email addresses weren't clickable, and it also wasn't possible to copy them to clipboard. It was a simple fix to do, so I've added the possibility to click on them.
The change was tested locally on Simple Thank You app, and it was working correctly.