### PR TITLE
Allow renaming files by just changing a letter casing

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
@@ -63,12 +63,12 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
 
                         val newPath = "${path.getParentPath()}/$newName"
 
-                        if(path == newPath){
+                        if (path == newPath){
                             activity.toast(R.string.name_taken)
                             return@setOnClickListener
                         }
 
-                        if(!path.equals(newPath, ignoreCase = true) && activity.getDoesFilePathExist(newPath)){
+                        if (!path.equals(newPath, ignoreCase = true) && activity.getDoesFilePathExist(newPath)){
                             activity.toast(R.string.name_taken)
                             return@setOnClickListener
                         }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
@@ -32,12 +32,7 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
             .create().apply {
                 activity.setupDialogStuff(view, this, R.string.rename) {
                     showKeyboard(view.rename_item_name)
-                    val positiveButton = getButton(AlertDialog.BUTTON_POSITIVE)
-                    positiveButton.isEnabled = false
-                    view.rename_item_name.onTextChangeListener { newName->
-                        positiveButton.isEnabled = name != newName
-                    }
-                    positiveButton.setOnClickListener {
+                    getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
                         if (ignoreClicks) {
                             return@setOnClickListener
                         }
@@ -67,6 +62,12 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
                         }
 
                         val newPath = "${path.getParentPath()}/$newName"
+
+                        if(path == newPath){
+                            activity.toast(R.string.name_taken)
+                            return@setOnClickListener
+                        }
+
                         if(!path.equals(newPath, ignoreCase = true) && activity.getDoesFilePathExist(newPath)){
                             activity.toast(R.string.name_taken)
                             return@setOnClickListener

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
@@ -32,7 +32,12 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
             .create().apply {
                 activity.setupDialogStuff(view, this, R.string.rename) {
                     showKeyboard(view.rename_item_name)
-                    getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
+                    val positiveButton = getButton(AlertDialog.BUTTON_POSITIVE)
+                    positiveButton.isEnabled = false
+                    view.rename_item_name.onTextChangeListener { newName->
+                        positiveButton.isEnabled = name != newName
+                    }
+                    positiveButton.setOnClickListener {
                         if (ignoreClicks) {
                             return@setOnClickListener
                         }
@@ -62,7 +67,7 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
                         }
 
                         val newPath = "${path.getParentPath()}/$newName"
-                        if (activity.getDoesFilePathExist(newPath)) {
+                        if(!path.equals(newPath, ignoreCase = true) && activity.getDoesFilePathExist(newPath)){
                             activity.toast(R.string.name_taken)
                             return@setOnClickListener
                         }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -6,7 +6,6 @@ import android.content.*
 import android.content.Intent.EXTRA_STREAM
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
-import android.content.res.ColorStateList
 import android.media.RingtoneManager
 import android.net.Uri
 import android.os.TransactionTooLargeException
@@ -705,7 +704,7 @@ fun BaseSimpleActivity.renameFile(oldPath: String, newPath: String, callback: ((
         val tempToNewSucceeds = tempFile.renameTo(newFile)
         if (oldToTempSucceeds && tempToNewSucceeds) {
             if (newFile.isDirectory) {
-                deleteFromMediaStore(oldPath)
+                updateInMediaStore(oldPath , newPath)
                 rescanPath(newPath) {
                     runOnUiThread {
                         callback?.invoke(true)
@@ -716,7 +715,7 @@ fun BaseSimpleActivity.renameFile(oldPath: String, newPath: String, callback: ((
                 if (!baseConfig.keepLastModified) {
                     newFile.setLastModified(System.currentTimeMillis())
                 }
-                deleteFromMediaStore(oldPath)
+                updateInMediaStore(oldPath , newPath)
                 scanPathsRecursively(arrayListOf(newPath)) {
                     runOnUiThread {
                         callback?.invoke(true)
@@ -937,20 +936,15 @@ fun Activity.setupDialogStuff(view: View, dialog: AlertDialog, titleId: Int = 0,
         }
     }
 
-    val buttonStates = arrayOf(intArrayOf(android.R.attr.state_enabled), intArrayOf(-android.R.attr.state_enabled))
-    val adjustedPrimaryColor50Alpha = adjustedPrimaryColor.adjustAlpha(0.5f)
-    val buttonColors = intArrayOf(adjustedPrimaryColor, adjustedPrimaryColor50Alpha)
-    val primaryButtonColor = ColorStateList(buttonStates, buttonColors)
-
     dialog.apply {
         setView(view)
         requestWindowFeature(Window.FEATURE_NO_TITLE)
         setCustomTitle(title)
         setCanceledOnTouchOutside(cancelOnTouchOutside)
         show()
-        getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(primaryButtonColor)
-        getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(primaryButtonColor)
-        getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(primaryButtonColor)
+        getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(adjustedPrimaryColor)
+        getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(adjustedPrimaryColor)
+        getButton(AlertDialog.BUTTON_NEUTRAL).setTextColor(adjustedPrimaryColor)
 
         val bgDrawable = resources.getColoredDrawableWithColor(R.drawable.dialog_bg, baseConfig.backgroundColor)
         window?.setBackgroundDrawable(bgDrawable)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -704,7 +704,7 @@ fun BaseSimpleActivity.renameFile(oldPath: String, newPath: String, callback: ((
         val tempToNewSucceeds = tempFile.renameTo(newFile)
         if (oldToTempSucceeds && tempToNewSucceeds) {
             if (newFile.isDirectory) {
-                updateInMediaStore(oldPath , newPath)
+                updateInMediaStore(oldPath, newPath)
                 rescanPath(newPath) {
                     runOnUiThread {
                         callback?.invoke(true)
@@ -715,7 +715,7 @@ fun BaseSimpleActivity.renameFile(oldPath: String, newPath: String, callback: ((
                 if (!baseConfig.keepLastModified) {
                     newFile.setLastModified(System.currentTimeMillis())
                 }
-                updateInMediaStore(oldPath , newPath)
+                updateInMediaStore(oldPath, newPath)
                 scanPathsRecursively(arrayListOf(newPath)) {
                     runOnUiThread {
                         callback?.invoke(true)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/File.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/File.kt
@@ -141,3 +141,11 @@ fun File.getDigest(algorithm: String): String {
 }
 
 fun File.md5(): String = this.getDigest(MD5)
+
+fun File.createTempFile(): File {
+    return if (isDirectory) {
+        createTempDir("temp", "${System.currentTimeMillis()}", parentFile)
+    } else {
+        createTempFile("temp", "${System.currentTimeMillis()}", parentFile)
+    }
+}


### PR DESCRIPTION
**Notes**
- Allow renaming files by just changing a letter casing
- when renaming, a temporary file/directory is created and the old file/directory is renamed to the temporary file/directory, thereafter, the temporary file/directory is renamed to the new file/directory.

**Screenshots**
<img src="https://user-images.githubusercontent.com/25648077/130207025-123141b1-7d23-428b-9da8-2b0f9448fd91.gif" alt="Screenshot" width="302">


> There's an issue when renaming on SD cards, using the [DocumentsContract.renameDocument](https://github.com/KryptKode/Simple-Commons/blob/ref/allow-case-name-change/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt#L673) method, when just the case of the file name changes, it appends an integer to the name. For example, `hello` becomes `Hello (1)` when trying to rename to `Hello`  No workaround has been identified for now.  See the screenshot below. 

<img src="https://user-images.githubusercontent.com/25648077/130207708-28b5855e-f582-425a-a6af-835843fb0b26.gif" alt="Screenshot" width="302">







 