### PR TITLE
Add support for biometric ID in SecurityDialog when targeting API 30+

### DIFF
--- a/commons/build.gradle
+++ b/commons/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'joda-time:joda-time:2.10.3'
     implementation "androidx.exifinterface:exifinterface:1.3.2"
+    implementation "androidx.biometric:biometric-ktx:1.2.0-alpha03"
 
     api 'androidx.appcompat:appcompat:1.2.0'
     api 'com.github.ajalt.reprint:core:3.3.2@aar'

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/PasswordTypesAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/PasswordTypesAdapter.kt
@@ -5,21 +5,32 @@ import android.util.SparseArray
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.biometric.auth.AuthPromptHost
 import androidx.viewpager.widget.PagerAdapter
 import com.simplemobiletools.commons.R
-import com.simplemobiletools.commons.extensions.isFingerPrintSensorAvailable
+import com.simplemobiletools.commons.extensions.isTargetSdkVersion30Plus
+import com.simplemobiletools.commons.helpers.PROTECTION_FINGERPRINT
+import com.simplemobiletools.commons.helpers.PROTECTION_PATTERN
+import com.simplemobiletools.commons.helpers.PROTECTION_PIN
 import com.simplemobiletools.commons.interfaces.HashListener
 import com.simplemobiletools.commons.interfaces.SecurityTab
 import com.simplemobiletools.commons.views.MyScrollView
 
-class PasswordTypesAdapter(val context: Context, val requiredHash: String, val hashListener: HashListener, val scrollView: MyScrollView) : PagerAdapter() {
+class PasswordTypesAdapter(
+    private val context: Context,
+    private val requiredHash: String,
+    private val hashListener: HashListener,
+    private val scrollView: MyScrollView,
+    private val biometricPromptHost: AuthPromptHost,
+    private val showBiometricIdTab: Boolean
+) : PagerAdapter() {
     private val tabs = SparseArray<SecurityTab>()
 
     override fun instantiateItem(container: ViewGroup, position: Int): Any {
         val view = LayoutInflater.from(context).inflate(layoutSelection(position), container, false)
         container.addView(view)
         tabs.put(position, view as SecurityTab)
-        (view as SecurityTab).initTab(requiredHash, hashListener, scrollView)
+        (view as SecurityTab).initTab(requiredHash, hashListener, scrollView, biometricPromptHost)
         return view
     }
 
@@ -28,14 +39,14 @@ class PasswordTypesAdapter(val context: Context, val requiredHash: String, val h
         container.removeView(item as View)
     }
 
-    override fun getCount() = if (context.isFingerPrintSensorAvailable()) 3 else 2
+    override fun getCount() = if (showBiometricIdTab) 3 else 2
 
     override fun isViewFromObject(view: View, item: Any) = view == item
 
     private fun layoutSelection(position: Int): Int = when (position) {
-        0 -> R.layout.tab_pattern
-        1 -> R.layout.tab_pin
-        2 -> R.layout.tab_fingerprint
+        PROTECTION_PATTERN -> R.layout.tab_pattern
+        PROTECTION_PIN -> R.layout.tab_pin
+        PROTECTION_FINGERPRINT -> if (context.isTargetSdkVersion30Plus()) R.layout.tab_biometric_id else R.layout.tab_fingerprint
         else -> throw RuntimeException("Only 3 tabs allowed")
     }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -8,7 +8,6 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageManager
 import android.media.RingtoneManager
 import android.net.Uri
-import android.os.Build
 import android.os.TransactionTooLargeException
 import android.provider.ContactsContract
 import android.provider.DocumentsContract
@@ -23,9 +22,12 @@ import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.TextView
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.auth.AuthPromptCallback
+import androidx.biometric.auth.AuthPromptHost
+import androidx.biometric.auth.Class2BiometricAuthPrompt
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import com.simplemobiletools.commons.R
@@ -859,6 +861,30 @@ fun BaseSimpleActivity.getFileOutputStreamSync(path: String, mimeType: String, p
             null
         }
     }
+}
+
+fun FragmentActivity.showBiometricPrompt(successCallback: (BiometricPrompt.AuthenticationResult) -> Unit) {
+    Class2BiometricAuthPrompt.Builder(getText(R.string.authenticate), getText(R.string.cancel))
+        .build()
+        .startAuthentication(
+            AuthPromptHost(this),
+            object : AuthPromptCallback() {
+                override fun onAuthenticationSucceeded(activity: FragmentActivity?, result: BiometricPrompt.AuthenticationResult) {
+                    successCallback(result)
+                }
+
+                override fun onAuthenticationError(activity: FragmentActivity?, errorCode: Int, errString: CharSequence) {
+                    val isCanceledByUser = errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED
+                    if (!isCanceledByUser) {
+                        toast(errString.toString())
+                    }
+                }
+
+                override fun onAuthenticationFailed(activity: FragmentActivity?) {
+                    toast(R.string.authentication_failed)
+                }
+            }
+        )
 }
 
 fun FragmentActivity.handleHiddenFolderPasswordProtection(callback: () -> Unit) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -32,6 +32,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.annotation.RequiresApi
+import androidx.biometric.BiometricManager
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.exifinterface.media.ExifInterface
@@ -150,7 +151,16 @@ val Context.sdCardPath: String get() = baseConfig.sdCardPath
 val Context.internalStoragePath: String get() = baseConfig.internalStoragePath
 val Context.otgPath: String get() = baseConfig.OTGPath
 
+val Context.targetSdkVersion: Int get() = applicationInfo.targetSdkVersion
+
+fun Context.isTargetSdkVersion30Plus(): Boolean = targetSdkVersion >= Build.VERSION_CODES.R
+
 fun Context.isFingerPrintSensorAvailable() = isMarshmallowPlus() && Reprint.isHardwarePresent()
+
+fun Context.isBiometricIdAvailable(): Boolean = when (BiometricManager.from(this).canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK)) {
+    BiometricManager.BIOMETRIC_SUCCESS, BiometricManager.BIOMETRIC_STATUS_UNKNOWN -> true
+    else -> false
+}
 
 fun Context.getLatestMediaId(uri: Uri = Files.getContentUri("external")): Long {
     val projection = arrayOf(
@@ -900,12 +910,14 @@ fun Context.getMediaStoreLastModified(path: String): Long {
 
 fun Context.getStringsPackageName() = getString(R.string.package_name)
 
-fun Context.getFontSizeText() = getString(when (baseConfig.fontSize) {
-    FONT_SIZE_SMALL -> R.string.small
-    FONT_SIZE_MEDIUM -> R.string.medium
-    FONT_SIZE_LARGE -> R.string.large
-    else -> R.string.extra_large
-})
+fun Context.getFontSizeText() = getString(
+    when (baseConfig.fontSize) {
+        FONT_SIZE_SMALL -> R.string.small
+        FONT_SIZE_MEDIUM -> R.string.medium
+        FONT_SIZE_LARGE -> R.string.large
+        else -> R.string.extra_large
+    }
+)
 
 fun Context.getTextSize() = when (baseConfig.fontSize) {
     FONT_SIZE_SMALL -> resources.getDimension(R.dimen.smaller_text_size)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/SecurityTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/SecurityTab.kt
@@ -1,9 +1,10 @@
 package com.simplemobiletools.commons.interfaces
 
+import androidx.biometric.auth.AuthPromptHost
 import com.simplemobiletools.commons.views.MyScrollView
 
 interface SecurityTab {
-    fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView)
+    fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost)
 
     fun visibilityChanged(isVisible: Boolean)
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
@@ -20,9 +20,7 @@ class BiometricIdTab(context: Context, attrs: AttributeSet) : ConstraintLayout(c
         context.updateTextColors(biometric_lock_holder)
 
         open_biometric_dialog.setOnClickListener {
-            biometricPromptHost.activity?.showBiometricPrompt {
-                hashListener.receivedHash("", PROTECTION_FINGERPRINT)
-            }
+            biometricPromptHost.activity?.showBiometricPrompt(successCallback = hashListener::receivedHash)
         }
     }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
@@ -1,0 +1,62 @@
+package com.simplemobiletools.commons.views
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.auth.AuthPromptCallback
+import androidx.biometric.auth.AuthPromptHost
+import androidx.biometric.auth.Class2BiometricAuthPrompt
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.fragment.app.FragmentActivity
+import com.simplemobiletools.commons.R
+import com.simplemobiletools.commons.extensions.toast
+import com.simplemobiletools.commons.extensions.updateTextColors
+import com.simplemobiletools.commons.helpers.PROTECTION_FINGERPRINT
+import com.simplemobiletools.commons.interfaces.HashListener
+import com.simplemobiletools.commons.interfaces.SecurityTab
+import kotlinx.android.synthetic.main.tab_biometric_id.view.*
+
+class BiometricIdTab(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs), SecurityTab {
+    private lateinit var hashListener: HashListener
+    private lateinit var biometricPromptHost: AuthPromptHost
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        context.updateTextColors(biometric_lock_holder)
+
+        open_biometric_dialog.setOnClickListener {
+            showBiometricPrompt()
+        }
+    }
+
+    private fun showBiometricPrompt() {
+        Class2BiometricAuthPrompt.Builder(context.getText(R.string.authenticate), context.getText(R.string.cancel))
+            .build()
+            .startAuthentication(
+                biometricPromptHost,
+                object : AuthPromptCallback() {
+                    override fun onAuthenticationSucceeded(activity: FragmentActivity?, result: BiometricPrompt.AuthenticationResult) {
+                        hashListener.receivedHash("", PROTECTION_FINGERPRINT)
+                    }
+
+                    override fun onAuthenticationError(activity: FragmentActivity?, errorCode: Int, errString: CharSequence) {
+                        val isCanceledByUser = errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED
+                        if (!isCanceledByUser) {
+                            context.toast(errString.toString())
+                        }
+                    }
+
+                    override fun onAuthenticationFailed(activity: FragmentActivity?) {
+                        context.toast(R.string.authentication_failed)
+                    }
+                }
+            )
+    }
+
+    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost) {
+        this.biometricPromptHost = biometricPromptHost
+        hashListener = listener
+    }
+
+    override fun visibilityChanged(isVisible: Boolean) {}
+}

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
@@ -2,14 +2,9 @@ package com.simplemobiletools.commons.views
 
 import android.content.Context
 import android.util.AttributeSet
-import androidx.biometric.BiometricPrompt
-import androidx.biometric.auth.AuthPromptCallback
 import androidx.biometric.auth.AuthPromptHost
-import androidx.biometric.auth.Class2BiometricAuthPrompt
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.fragment.app.FragmentActivity
-import com.simplemobiletools.commons.R
-import com.simplemobiletools.commons.extensions.toast
+import com.simplemobiletools.commons.extensions.showBiometricPrompt
 import com.simplemobiletools.commons.extensions.updateTextColors
 import com.simplemobiletools.commons.helpers.PROTECTION_FINGERPRINT
 import com.simplemobiletools.commons.interfaces.HashListener
@@ -25,32 +20,10 @@ class BiometricIdTab(context: Context, attrs: AttributeSet) : ConstraintLayout(c
         context.updateTextColors(biometric_lock_holder)
 
         open_biometric_dialog.setOnClickListener {
-            showBiometricPrompt()
+            biometricPromptHost.activity?.showBiometricPrompt {
+                hashListener.receivedHash("", PROTECTION_FINGERPRINT)
+            }
         }
-    }
-
-    private fun showBiometricPrompt() {
-        Class2BiometricAuthPrompt.Builder(context.getText(R.string.authenticate), context.getText(R.string.cancel))
-            .build()
-            .startAuthentication(
-                biometricPromptHost,
-                object : AuthPromptCallback() {
-                    override fun onAuthenticationSucceeded(activity: FragmentActivity?, result: BiometricPrompt.AuthenticationResult) {
-                        hashListener.receivedHash("", PROTECTION_FINGERPRINT)
-                    }
-
-                    override fun onAuthenticationError(activity: FragmentActivity?, errorCode: Int, errString: CharSequence) {
-                        val isCanceledByUser = errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED
-                        if (!isCanceledByUser) {
-                            context.toast(errString.toString())
-                        }
-                    }
-
-                    override fun onAuthenticationFailed(activity: FragmentActivity?) {
-                        context.toast(R.string.authentication_failed)
-                    }
-                }
-            )
     }
 
     override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/FingerprintTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/FingerprintTab.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.provider.Settings
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.biometric.auth.AuthPromptHost
 import com.github.ajalt.reprint.core.AuthenticationFailureReason
 import com.github.ajalt.reprint.core.AuthenticationListener
 import com.github.ajalt.reprint.core.Reprint
@@ -33,7 +34,7 @@ class FingerprintTab(context: Context, attrs: AttributeSet) : RelativeLayout(con
         }
     }
 
-    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView) {
+    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost) {
         hashListener = listener
     }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.widget.RelativeLayout
+import androidx.biometric.auth.AuthPromptHost
 import com.andrognito.patternlockview.PatternLockView
 import com.andrognito.patternlockview.listener.PatternLockViewListener
 import com.andrognito.patternlockview.utils.PatternLockUtils
@@ -52,7 +53,7 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
         })
     }
 
-    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView) {
+    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost) {
         this.requiredHash = requiredHash
         this.scrollView = scrollView
         hash = requiredHash

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.commons.views
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.RelativeLayout
+import androidx.biometric.auth.AuthPromptHost
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.PROTECTION_PIN
@@ -38,7 +39,7 @@ class PinTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, at
         pin_ok.applyColorFilter(context.baseConfig.textColor)
     }
 
-    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView) {
+    override fun initTab(requiredHash: String, listener: HashListener, scrollView: MyScrollView, biometricPromptHost: AuthPromptHost) {
         this.requiredHash = requiredHash
         hash = requiredHash
         hashListener = listener
@@ -98,7 +99,7 @@ class PinTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, at
         messageDigest.update(pin.toByteArray(charset("UTF-8")))
         val digest = messageDigest.digest()
         val bigInteger = BigInteger(1, digest)
-        return String.format(Locale.getDefault(), "%0${digest.size * 2}x", bigInteger).toLowerCase()
+        return String.format(Locale.getDefault(), "%0${digest.size * 2}x", bigInteger).lowercase(Locale.getDefault())
     }
 
     override fun visibilityChanged(isVisible: Boolean) {}

--- a/commons/src/main/res/layout/dialog_security.xml
+++ b/commons/src/main/res/layout/dialog_security.xml
@@ -31,7 +31,7 @@
                 android:id="@+id/dialog_tab_fingerprint"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/fingerprint"/>
+                android:text="@string/biometrics"/>
 
         </com.google.android.material.tabs.TabLayout>
 

--- a/commons/src/main/res/layout/tab_biometric_id.xml
+++ b/commons/src/main/res/layout/tab_biometric_id.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.simplemobiletools.commons.views.BiometricIdTab xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/biometric_lock_holder"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.simplemobiletools.commons.views.MyButton
+        android:id="@+id/open_biometric_dialog"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/button_background"
+        android:padding="@dimen/normal_margin"
+        android:text="@string/open_biometric_dialog"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</com.simplemobiletools.commons.views.BiometricIdTab>

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -338,6 +338,8 @@
     <string name="fingerprint">البصمة</string>
     <string name="add_fingerprint">إضافة بصمة</string>
     <string name="place_finger">يرجى وضع إصبعك على مستشعر البصمة</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">فشلت المسابقة</string>
     <string name="authentication_blocked">تم حظر المصادقة ، يرجى المحاولة مره أخرى بعد قليل</string>
     <string name="no_fingerprints_registered">ليس لديك بصمات مسجلة ، يرجى إضافة بعضها في إعدادات جهازك</string>

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -335,6 +335,7 @@
     <string name="insert_pattern">إدراج النمط</string>
     <string name="wrong_pattern">النمط غير صحيح</string>
     <string name="repeat_pattern">تكرار النمط</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">البصمة</string>
     <string name="add_fingerprint">إضافة بصمة</string>
     <string name="place_finger">يرجى وضع إصبعك على مستشعر البصمة</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Model daxil edin</string>
     <string name="wrong_pattern">Yanlış model</string>
     <string name="repeat_pattern">Modeli təkrarlayın</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Barmaq izi</string>
     <string name="add_fingerprint">Barmaq izi əlavə et</string>
     <string name="place_finger">Xahiş olunur barmağınızı barmaq izi sensoru üzərinə yerləşdirin</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Barmaq izi</string>
     <string name="add_fingerprint">Barmaq izi əlavə et</string>
     <string name="place_finger">Xahiş olunur barmağınızı barmaq izi sensoru üzərinə yerləşdirin</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Uyğunlaşdırma uğursuzdur</string>
     <string name="authentication_blocked">Uyğunlaşdırma bloklanıb, biraz sonra yoxlayın</string>
     <string name="no_fingerprints_registered">Qeydiyyata alınmış heçbir barmaq izi yoxdur, xahiş olunur cihazınızın Parametrlərindən əlavə edəsiniz</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insert pattern</string>
     <string name="wrong_pattern">Wrong pattern</string>
     <string name="repeat_pattern">Repeat pattern</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Introdueix patró</string>
     <string name="wrong_pattern">Patró erroni</string>
     <string name="repeat_pattern">Repeteix patró</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Empremta digital</string>
     <string name="add_fingerprint">Afegeix Empremta digital</string>
     <string name="place_finger">Si us plau posa el teu dit al sensor d’empremta digital</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Empremta digital</string>
     <string name="add_fingerprint">Afegeix Empremta digital</string>
     <string name="place_finger">Si us plau posa el teu dit al sensor d’empremta digital</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">L\'autenticació ha fallat</string>
     <string name="authentication_blocked">L\'autenticació està bloquejada. Prova-ho d’aquí un moment</string>
     <string name="no_fingerprints_registered">No tens empremtes digitals registrades. Afegeix-ne alguna a la configuració del dispositiu</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -342,6 +342,7 @@
     <string name="insert_pattern">Zadejte vzor</string>
     <string name="wrong_pattern">Nesprávný vzor</string>
     <string name="repeat_pattern">Opakovat vzor</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Otisk</string>
     <string name="add_fingerprint">Potvrďte otisk prstu</string>
     <string name="place_finger">Prosím přiložte prst na senzor otisku prstu</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -345,6 +345,8 @@
     <string name="fingerprint">Otisk</string>
     <string name="add_fingerprint">Potvrďte otisk prstu</string>
     <string name="place_finger">Prosím přiložte prst na senzor otisku prstu</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Ověření selhalo</string>
     <string name="authentication_blocked">Ověření je blokováno, zkuste to prosím později</string>
     <string name="no_fingerprints_registered">Nejsou registrovány žádné otisky prstu, prosím přidejte nějaké v nastavení svého zařízení</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -349,6 +349,7 @@
     <string name="insert_pattern">Rho batrwm</string>
     <string name="wrong_pattern">Patrwm anghywir</string>
     <string name="repeat_pattern">Rho\'r patrwm eto</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Ôl byd</string>
     <string name="add_fingerprint">Ychwanegu ôl bys</string>
     <string name="place_finger">Gosoda dy fys ar y synhwyrydd olion bysedd</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -352,6 +352,8 @@
     <string name="fingerprint">Ôl byd</string>
     <string name="add_fingerprint">Ychwanegu ôl bys</string>
     <string name="place_finger">Gosoda dy fys ar y synhwyrydd olion bysedd</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Methodd y dilysiad</string>
     <string name="authentication_blocked">Rhwystrwyd y dilysiad. Rho gynnig arall arni mewn eiliad</string>
     <string name="no_fingerprints_registered">Does dim olion bysedd wedi\'u cofrestru. Ychwanega rai yn Gosodiadau dy ddyfais.</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingeraftryk</string>
     <string name="add_fingerprint">Tilføj fingeraftryk</string>
     <string name="place_finger">Sæt din finger på sensoren</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Godkendelsen fejlede</string>
     <string name="authentication_blocked">Godkendelse blokeret, prøv igen om lidt</string>
     <string name="no_fingerprints_registered">Du har ingen registrerede fingeraftryk, tilføj nogle i indstillingerne på din enhed</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Indsæt mønster</string>
     <string name="wrong_pattern">Forkert mønster</string>
     <string name="repeat_pattern">Gentag mønster</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingeraftryk</string>
     <string name="add_fingerprint">Tilføj fingeraftryk</string>
     <string name="place_finger">Sæt din finger på sensoren</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingerabdruck</string>
     <string name="add_fingerprint">Fingerabdruck hinzufügen</string>
     <string name="place_finger">Bitte den Finger auf den Fingerabdrucksensor legen</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentifizierung fehlgeschlagen</string>
     <string name="authentication_blocked">Authentifizierung blockiert, bitte in Kürze erneut versuchen</string>
     <string name="no_fingerprints_registered">Keine Fingerabdrücke registriert, bitte in den Geräteeinstellungen hinzufügen</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Muster zeichnen</string>
     <string name="wrong_pattern">Falsches Muster</string>
     <string name="repeat_pattern">Muster wiederholen</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingerabdruck</string>
     <string name="add_fingerprint">Fingerabdruck hinzufügen</string>
     <string name="place_finger">Bitte den Finger auf den Fingerabdrucksensor legen</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Εισαγωγή μοτίβου</string>
     <string name="wrong_pattern">Λάθος μοτίβο</string>
     <string name="repeat_pattern">Επανάληψη μοτίβου</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Δακτυλικό αποτύπωμα</string>
     <string name="add_fingerprint">Προσθήκη δακτυλικού αποτυπώματος</string>
     <string name="place_finger">Παρακαλώ τοποθετήστε το δάκτυλό σας στον αισθητήρα δακτυλικών αποτυπωμάτων</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Δακτυλικό αποτύπωμα</string>
     <string name="add_fingerprint">Προσθήκη δακτυλικού αποτυπώματος</string>
     <string name="place_finger">Παρακαλώ τοποθετήστε το δάκτυλό σας στον αισθητήρα δακτυλικών αποτυπωμάτων</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Ο έλεγχος ταυτότητας απέτυχε</string>
     <string name="authentication_blocked">Αποκλεισμός ελέγχου ταυτότητας, προσπαθήστε ξανά σε λίγο</string>
     <string name="no_fingerprints_registered">Δεν έχετε καταχωρήσει δακτυλικά αποτυπώματα, προσθέστε μερικά στις Ρυθμίσεις της συσκευής σας</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Huella</string>
     <string name="add_fingerprint">Añadir huella</string>
     <string name="place_finger">Por favor pon el dedo en el lector de huellas</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autenticación fallida</string>
     <string name="authentication_blocked">Autenticación bloqueada, por favor intente de nuevo en un momento</string>
     <string name="no_fingerprints_registered">No tiene huellas dactilares registradas, por favor agregue algunas en la configuración de su dispositivo</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Inserte Patrón</string>
     <string name="wrong_pattern">Patrón erroneo</string>
     <string name="repeat_pattern">Repetir Patrón</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Huella</string>
     <string name="add_fingerprint">Añadir huella</string>
     <string name="place_finger">Por favor pon el dedo en el lector de huellas</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Sartu eredua</string>
     <string name="wrong_pattern">Okerreko eredua</string>
     <string name="repeat_pattern">Errepikatu eredua</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Hatz-marka</string>
     <string name="add_fingerprint">Gehitu hatz-marka</string>
     <string name="place_finger">Jarri hatza hatz-markaren sensorean</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Hatz-marka</string>
     <string name="add_fingerprint">Gehitu hatz-marka</string>
     <string name="place_finger">Jarri hatza hatz-markaren sensorean</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentifikazioak huts egin du</string>
     <string name="authentication_blocked">Autentifikazioa blokeatuta, saiatu berriro geroago</string>
     <string name="no_fingerprints_registered">Ez duzu hatz-markarik erregistratu, gehitu batzuk zeure gailuko ezarpenetan</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">الگو را وارد کنید</string>
     <string name="wrong_pattern">الگو اشتباه است</string>
     <string name="repeat_pattern">الگو را تکرار کنید</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">اثر انگشت</string>
     <string name="add_fingerprint">افزودن اثر انگشت</string>
     <string name="place_finger">لطفا انگشت خود را روی حسگر اثر انگشت قرار دهید</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">اثر انگشت</string>
     <string name="add_fingerprint">افزودن اثر انگشت</string>
     <string name="place_finger">لطفا انگشت خود را روی حسگر اثر انگشت قرار دهید</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">احراز هویت ناموفق</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Sormenjälki</string>
     <string name="add_fingerprint">Lisää sormenjälki</string>
     <string name="place_finger">Aseta sormi sormenjälkitunnistimelle</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Kirjautuminen epäonnistui</string>
     <string name="authentication_blocked">Kirjautuminen estetty, yritä myöhemmin uudelleen</string>
     <string name="no_fingerprints_registered">Sinulla ei ole tallennettuja sormenjälkiä, lisää niitä laitteesi asetuksista</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Syötä kuvio</string>
     <string name="wrong_pattern">Väärä kuvio</string>
     <string name="repeat_pattern">Toista kuvio</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Sormenjälki</string>
     <string name="add_fingerprint">Lisää sormenjälki</string>
     <string name="place_finger">Aseta sormi sormenjälkitunnistimelle</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -342,6 +342,8 @@
     <string name="fingerprint">Empreinte</string>
     <string name="add_fingerprint">Capturer une empreinte</string>
     <string name="place_finger">Veuillez placer votre doigt sur le capteur d\'empreinte digitale</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Échec de l\'identification</string>
     <string name="authentication_blocked">Identification bloquée. Veuillez réessayer dans quelques instants.</string>
     <string name="no_fingerprints_registered">Vous n\'avez aucune empreinte digitale enregistrée. Veuillez en ajouter depuis les paramètres de votre appareil</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -339,6 +339,7 @@
     <string name="insert_pattern">Dessiner un schéma</string>
     <string name="wrong_pattern">Schéma incorrect</string>
     <string name="repeat_pattern">Redessiner le schéma</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Empreinte</string>
     <string name="add_fingerprint">Capturer une empreinte</string>
     <string name="place_finger">Veuillez placer votre doigt sur le capteur d\'empreinte digitale</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Pegada dixital</string>
     <string name="add_fingerprint">Engadir pegada dixital</string>
     <string name="place_finger">Pon o dedo no lector de pegadas dixitais</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autenticación fallada</string>
     <string name="authentication_blocked">Autenticación bloqueada; por favor, inténtao de novo dentro dun pouco</string>
     <string name="no_fingerprints_registered">Non tes pegadas dixitais rexistradas; por favor, engada algunhas na Configuración do teu dispositivo</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insire patrón</string>
     <string name="wrong_pattern">Patrón erróneo</string>
     <string name="repeat_pattern">Repetir patrón</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Pegada dixital</string>
     <string name="add_fingerprint">Engadir pegada dixital</string>
     <string name="place_finger">Pon o dedo no lector de pegadas dixitais</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insert pattern</string>
     <string name="wrong_pattern">Wrong pattern</string>
     <string name="repeat_pattern">Repeat pattern</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -343,6 +343,8 @@
     <string name="fingerprint">Otisak prsta</string>
     <string name="add_fingerprint">Dodajte otisak prsta</string>
     <string name="place_finger">Molimo postavite prst na senzor otiska prsta</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Neuspješna autentifikacija</string>
     <string name="authentication_blocked">Blokirana autentifikacija, molimo pokušajte za par trenutaka</string>
     <string name="no_fingerprints_registered">Nemate registiranih otisaka prstiju, molimo dodajte ih u postavkama Vašeg uređaja</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -340,6 +340,7 @@
     <string name="insert_pattern">Unesite uzorak</string>
     <string name="wrong_pattern">Krivi uzorak</string>
     <string name="repeat_pattern">Ponovite uzorak</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Otisak prsta</string>
     <string name="add_fingerprint">Dodajte otisak prsta</string>
     <string name="place_finger">Molimo postavite prst na senzor otiska prsta</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -339,6 +339,8 @@
     <string name="fingerprint">Ujjlenyomat</string>
     <string name="add_fingerprint">Ujjlenyomat hozzáadása</string>
     <string name="place_finger">Helyezze az ujját az ujjlenyomat érzékelőre</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Sikertelen hitelesítés</string>
     <string name="authentication_blocked">A hitelesítés blokkolva, próbálkozzon újra egy kicsit később</string>
     <string name="no_fingerprints_registered">Nincsenek regisztrált ujjlenyomatok, kérjük, adjon hozzá néhányat a készülék Beállításaiban</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -336,6 +336,7 @@
     <string name="insert_pattern">Minta beillesztése</string>
     <string name="wrong_pattern">Hibás minta</string>
     <string name="repeat_pattern">Minta ismétlése</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Ujjlenyomat</string>
     <string name="add_fingerprint">Ujjlenyomat hozzáadása</string>
     <string name="place_finger">Helyezze az ujját az ujjlenyomat érzékelőre</string>

--- a/commons/src/main/res/values-id/strings.xml
+++ b/commons/src/main/res/values-id/strings.xml
@@ -333,6 +333,7 @@
     <string name="insert_pattern">Masukkan pola</string>
     <string name="wrong_pattern">Pola salah</string>
     <string name="repeat_pattern">Ulangi pola</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Sidik jari</string>
     <string name="add_fingerprint">Tambah sidik jari</string>
     <string name="place_finger">Tempatkan jari anda pada sensor sidik jari</string>

--- a/commons/src/main/res/values-id/strings.xml
+++ b/commons/src/main/res/values-id/strings.xml
@@ -336,6 +336,8 @@
     <string name="fingerprint">Sidik jari</string>
     <string name="add_fingerprint">Tambah sidik jari</string>
     <string name="place_finger">Tempatkan jari anda pada sensor sidik jari</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentikasi gagal</string>
     <string name="authentication_blocked">Autentikasi diblokir, silakan coba lagi nanti</string>
     <string name="no_fingerprints_registered">Anda belum mendaftarkan sidik jari, silakan tambahkan di Pengaturan perangkat anda</string>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -333,6 +333,7 @@
     <string name="insert_pattern">Masukkan pola</string>
     <string name="wrong_pattern">Pola salah</string>
     <string name="repeat_pattern">Ulangi pola</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Sidik jari</string>
     <string name="add_fingerprint">Tambah sidik jari</string>
     <string name="place_finger">Tempatkan jari anda pada sensor sidik jari</string>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -336,6 +336,8 @@
     <string name="fingerprint">Sidik jari</string>
     <string name="add_fingerprint">Tambah sidik jari</string>
     <string name="place_finger">Tempatkan jari anda pada sensor sidik jari</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentikasi gagal</string>
     <string name="authentication_blocked">Autentikasi diblokir, silakan coba lagi nanti</string>
     <string name="no_fingerprints_registered">Anda belum mendaftarkan sidik jari, silakan tambahkan di Pengaturan perangkat anda</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Impronta</string>
     <string name="add_fingerprint">Aggiungi un\'impronta</string>
     <string name="place_finger">Appoggia il dito sul sensore di impronte digitali</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autenticazione fallita</string>
     <string name="authentication_blocked">Autenticazione bloccata, riprovare fra qualche momento</string>
     <string name="no_fingerprints_registered">Non ci sono impronte registrate, aggiungerne alcune nelle impostazioni del tuo dispositivo</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Inserisci una sequenza</string>
     <string name="wrong_pattern">Sequenza errata</string>
     <string name="repeat_pattern">Ripeti la sequenza</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Impronta</string>
     <string name="add_fingerprint">Aggiungi un\'impronta</string>
     <string name="place_finger">Appoggia il dito sul sensore di impronte digitali</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">טביעת אצבע</string>
     <string name="add_fingerprint">הוספת טביעת אצבע</string>
     <string name="place_finger">נא להניח את טביעת האצבע על החיישן</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">זיהוי נכשל</string>
     <string name="authentication_blocked">זיהוי חסוי. נא לנסות שוב מאוחר יותר</string>
     <string name="no_fingerprints_registered">אין טביעות אצבע רשומות. נא להוסיף בהגדרות המכשיר</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">הכנס דפוס</string>
     <string name="wrong_pattern">דפוס שגוי</string>
     <string name="repeat_pattern">חזור על דפוס</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">טביעת אצבע</string>
     <string name="add_fingerprint">הוספת טביעת אצבע</string>
     <string name="place_finger">נא להניח את טביעת האצבע על החיישן</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -335,6 +335,8 @@
     <string name="fingerprint">指紋</string>
     <string name="add_fingerprint">指紋を追加</string>
     <string name="place_finger">指紋センサーに指を置いてください</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">認証に失敗しました</string>
     <string name="authentication_blocked">認証がブロックされました、しばらくしてからもう一度お試しください</string>
     <string name="no_fingerprints_registered">指紋がまだ登録されていません、お使いの端末の設定でいくつか追加してください</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -332,6 +332,7 @@
     <string name="insert_pattern">パターンを入力</string>
     <string name="wrong_pattern">パターンに誤りがあります</string>
     <string name="repeat_pattern">パターンを再入力</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">指紋</string>
     <string name="add_fingerprint">指紋を追加</string>
     <string name="place_finger">指紋センサーに指を置いてください</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -334,6 +334,8 @@
     <string name="fingerprint">지문</string>
     <string name="add_fingerprint">지문 추가</string>
     <string name="place_finger">지문 센서에 손가락을 올려주세요.</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">인증 실패</string>
     <string name="authentication_blocked">인증이 차단 되었습니다. 잠시 후 다시 시도하십시오.</string>
     <string name="no_fingerprints_registered">등록 된 지문이 없습니다. 기기의 설정에서 지문을 추가하십시오.</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -331,6 +331,7 @@
     <string name="insert_pattern">패턴 입력</string>
     <string name="wrong_pattern">패턴이 잘못 입력되었습니다.</string>
     <string name="repeat_pattern">패턴 확인</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">지문</string>
     <string name="add_fingerprint">지문 추가</string>
     <string name="place_finger">지문 센서에 손가락을 올려주세요.</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Įtraukti modelį</string>
     <string name="wrong_pattern">Klaidingas modelis</string>
     <string name="repeat_pattern">Pakartoti modelį</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Piršto atspaudas</string>
     <string name="add_fingerprint">Pridėti piršto atspaudą</string>
     <string name="place_finger">Prašome uždėti savo pirštą ant pirštų atspaudų jutiklio</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Piršto atspaudas</string>
     <string name="add_fingerprint">Pridėti piršto atspaudą</string>
     <string name="place_finger">Prašome uždėti savo pirštą ant pirštų atspaudų jutiklio</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentifikacija nepavyko</string>
     <string name="authentication_blocked">Autentifikacija blokuojama, prašome pabandyti iš naujo vėliau</string>
     <string name="no_fingerprints_registered">Neturite registruotų pirštų atspaudų, prašome įtraukti Jūsų įrenginio nustatymuose</string>

--- a/commons/src/main/res/values-nb/strings.xml
+++ b/commons/src/main/res/values-nb/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingeravtrykk</string>
     <string name="add_fingerprint">Legg til fingeravtrykk</string>
     <string name="place_finger">Plasser fingeren på fingeravtrykksensoren</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentisering feilet</string>
     <string name="authentication_blocked">Autentisering blokkert, prøv igjen</string>
     <string name="no_fingerprints_registered">Du har ingen fingeravtrykk registrert, legg til i enhetens innstillinger</string>

--- a/commons/src/main/res/values-nb/strings.xml
+++ b/commons/src/main/res/values-nb/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Tegn mønster</string>
     <string name="wrong_pattern">Feil mønster</string>
     <string name="repeat_pattern">Gjenta mønster</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingeravtrykk</string>
     <string name="add_fingerprint">Legg til fingeravtrykk</string>
     <string name="place_finger">Plasser fingeren på fingeravtrykksensoren</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Vingerafdruk</string>
     <string name="add_fingerprint">Voeg vingerafdruk toe</string>
     <string name="place_finger">Plaats uw vinger op de sensor</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authenticatie mislukt</string>
     <string name="authentication_blocked">Authenticatie geblokkeerd, probeer het op een ander moment</string>
     <string name="no_fingerprints_registered">Er zijn geen vingerafdrukken geregistreerd. Voeg deze toe via de instellingen van uw toestel.</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Teken een patroon</string>
     <string name="wrong_pattern">Verkeerde patroon</string>
     <string name="repeat_pattern">Herhaal het patroon</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Vingerafdruk</string>
     <string name="add_fingerprint">Voeg vingerafdruk toe</string>
     <string name="place_finger">Plaats uw vinger op de sensor</string>

--- a/commons/src/main/res/values-no/strings.xml
+++ b/commons/src/main/res/values-no/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values-no/strings.xml
+++ b/commons/src/main/res/values-no/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insert pattern</string>
     <string name="wrong_pattern">Wrong pattern</string>
     <string name="repeat_pattern">Repeat pattern</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -340,6 +340,7 @@
     <string name="insert_pattern">Wprowadź wzór</string>
     <string name="wrong_pattern">Nieprawidłowy wzór</string>
     <string name="repeat_pattern">Wprowadź wzór ponownie</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Odcisk palca</string>
     <string name="add_fingerprint">Dodaj odcisk palca</string>
     <string name="place_finger">Przyłóż palec do czytnika</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -343,6 +343,8 @@
     <string name="fingerprint">Odcisk palca</string>
     <string name="add_fingerprint">Dodaj odcisk palca</string>
     <string name="place_finger">Przyłóż palec do czytnika</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Uwierzytelnianie nie powiodło się.</string>
     <string name="authentication_blocked">Uwierzytelnianie zablokowane. Spróbuj ponownie za chwilę.</string>
     <string name="no_fingerprints_registered">Nie masz zarejestrowanych odcisków palców. Dodaj je w ustawieniach systemowych.</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Digital</string>
     <string name="add_fingerprint">Adicionar digital</string>
     <string name="place_finger">Posicione seu dedo sobre o leitor de digitais</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autenticação falhou</string>
     <string name="authentication_blocked">Autenticação bloqueada, favor tentar novamente em instantes</string>
     <string name="no_fingerprints_registered">Você não tem digitais cadastradas. Favor adiconar alguma nas Configurações do seu dispositivo</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Inserir padrão</string>
     <string name="wrong_pattern">Padrão errado</string>
     <string name="repeat_pattern">Repetir padrão</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Digital</string>
     <string name="add_fingerprint">Adicionar digital</string>
     <string name="place_finger">Posicione seu dedo sobre o leitor de digitais</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Impressão digital</string>
     <string name="add_fingerprint">Adicionar impressão digital</string>
     <string name="place_finger">Coloque o dedo no sensor de impressões digitais</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Falha de autenticação</string>
     <string name="authentication_blocked">Autenticação bloqueada. Por favor tente mais tarde.</string>
     <string name="no_fingerprints_registered">Não tem impressões digitais registadas. Adicione a sua impressão digital nas definições do dispositivo.</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Introduza o padrão</string>
     <string name="wrong_pattern">Padrão inválido</string>
     <string name="repeat_pattern">Repita o padrão</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Impressão digital</string>
     <string name="add_fingerprint">Adicionar impressão digital</string>
     <string name="place_finger">Coloque o dedo no sensor de impressões digitais</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -345,6 +345,8 @@
     <string name="fingerprint">Отпечаток пальца</string>
     <string name="add_fingerprint">Добавить отпечаток</string>
     <string name="place_finger">Поместите палец на датчик отпечатков</string>
+    <string name="open_biometric_dialog">Открыть диалог подтверджения биометрических данных</string>
+    <string name="authenticate">Авторизуйтесь</string>
     <string name="authentication_failed">Ошибка авторизации</string>
     <string name="authentication_blocked">Авторизация заблокирована, повторите попытку через некоторое время</string>
     <string name="no_fingerprints_registered">Отсутствуют зарегистрированные отпечатки пальцев, добавьте их в настройках устройства</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -342,6 +342,7 @@
     <string name="insert_pattern">Установить ключ</string>
     <string name="wrong_pattern">Неправильный графический ключ</string>
     <string name="repeat_pattern">Повторите ключ</string>
+    <string name="biometrics">Биометрические данные</string>
     <string name="fingerprint">Отпечаток пальца</string>
     <string name="add_fingerprint">Добавить отпечаток</string>
     <string name="place_finger">Поместите палец на датчик отпечатков</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -342,6 +342,7 @@
     <string name="insert_pattern">Zadajte vzor</string>
     <string name="wrong_pattern">Nesprávny vzor</string>
     <string name="repeat_pattern">Zopakujte vzor</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Odtlačok</string>
     <string name="add_fingerprint">Pridať odtlačok prsta</string>
     <string name="place_finger">Prosím priložte prst ku senzoru odtlačku prsta</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -345,6 +345,8 @@
     <string name="fingerprint">Odtlačok</string>
     <string name="add_fingerprint">Pridať odtlačok prsta</string>
     <string name="place_finger">Prosím priložte prst ku senzoru odtlačku prsta</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Overovanie zlyhalo</string>
     <string name="authentication_blocked">Overovanie je zablokované, prosím skúste o chvíľu</string>
     <string name="no_fingerprints_registered">Nemáte zaregistrované žiadne odtlačky, prosím pridajte nejaké v Nastaveniach zariadenia</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -344,6 +344,7 @@
     <string name="insert_pattern">Narišite vzorec</string>
     <string name="wrong_pattern">Napačen vzorec</string>
     <string name="repeat_pattern">Ponovite vzorec</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Prstni odtis</string>
     <string name="add_fingerprint">Dodaj prstni odtis</string>
     <string name="place_finger">Postavite prst na čitalec prstnih odtisov</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -347,6 +347,8 @@
     <string name="fingerprint">Prstni odtis</string>
     <string name="add_fingerprint">Dodaj prstni odtis</string>
     <string name="place_finger">Postavite prst na čitalec prstnih odtisov</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Overitev ni uspela</string>
     <string name="authentication_blocked">Overitev je blokirana, prosimo počakajte trenutek</string>
     <string name="no_fingerprints_registered">Registrirali še niste nobenega prstnega odtisa. Prosimo, dodajte jih v nastavitvah naprave</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -339,6 +339,8 @@
     <string name="fingerprint">Отисак прста</string>
     <string name="add_fingerprint">Додајте отисак прста</string>
     <string name="place_finger">Молимо вас ставите ваш прст на сензор за отисак прста</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Провера идентитета неуспешна</string>
     <string name="authentication_blocked">Провера идентитета блокирана, покушајте поново касније</string>
     <string name="no_fingerprints_registered">Немате регистрованих отисака прстију, додајте неке у Подешавања вашег уређаја</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -336,6 +336,7 @@
     <string name="insert_pattern">Унесите шаблон</string>
     <string name="wrong_pattern">Погрешан шаблон</string>
     <string name="repeat_pattern">Поновите шаблон</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Отисак прста</string>
     <string name="add_fingerprint">Додајте отисак прста</string>
     <string name="place_finger">Молимо вас ставите ваш прст на сензор за отисак прста</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Rita mönster</string>
     <string name="wrong_pattern">Du har ritat fel mönster</string>
     <string name="repeat_pattern">Upprepa mönster</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingeravtryck</string>
     <string name="add_fingerprint">Lägg till fingeravtryck</string>
     <string name="place_finger">Placera fingret på fingeravtrycksläsaren</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingeravtryck</string>
     <string name="add_fingerprint">Lägg till fingeravtryck</string>
     <string name="place_finger">Placera fingret på fingeravtrycksläsaren</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Autentiseringen misslyckades</string>
     <string name="authentication_blocked">Autentisering blockeras, försök igen om en stund</string>
     <string name="no_fingerprints_registered">Du har inga registrerade fingeravtryck, lägg till några i Inställningarna på din enhet</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insert pattern</string>
     <string name="wrong_pattern">Wrong pattern</string>
     <string name="repeat_pattern">Repeat pattern</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">கைரேகை</string>
     <string name="add_fingerprint">கைரேகை சேர்</string>
     <string name="place_finger">கைரேகை உணர்வியில் உமது விரலை வைக்கவும்</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">கைரேகை</string>
     <string name="add_fingerprint">கைரேகை சேர்</string>
     <string name="place_finger">கைரேகை உணர்வியில் உமது விரலை வைக்கவும்</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Deseni çiz</string>
     <string name="wrong_pattern">Yanlış desen</string>
     <string name="repeat_pattern">Deseni tekrar çiz</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Parmak izi</string>
     <string name="add_fingerprint">Parmak izi ekle</string>
     <string name="place_finger">Lütfen parmağınızı parmak izi sensörüne yerleştirin</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Parmak izi</string>
     <string name="add_fingerprint">Parmak izi ekle</string>
     <string name="place_finger">Lütfen parmağınızı parmak izi sensörüne yerleştirin</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Kimlik doğrulama başarısız</string>
     <string name="authentication_blocked">Kimlik doğrulama engellendi, lütfen birazdan tekrar deneyin</string>
     <string name="no_fingerprints_registered">Parmak iziniz kayıtlı değil, lütfen cihazınızın Ayarlar bölümünden ekleyin</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Відбиток пальця</string>
     <string name="add_fingerprint">Додати відбиток пальця</string>
     <string name="place_finger">Помістіть ваш палець на сканер відбитка пальця</string>
+    <string name="open_biometric_dialog">Відкрити діалог підтвердження біометричних даних</string>
+    <string name="authenticate">Авторизуйтеся</string>
     <string name="authentication_failed">Помилка автентифікації</string>
     <string name="authentication_blocked">Автентифікацію заблоковано, спробуйте це раз</string>
     <string name="no_fingerprints_registered">У вас немає зареєстрованих відбитків пальця, додайте їх у Налаштуваннях вашого пристрою</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Вставити шаблон</string>
     <string name="wrong_pattern">Невірний шаблон</string>
     <string name="repeat_pattern">Повторіть шаблон</string>
+    <string name="biometrics">Біометричні дані</string>
     <string name="fingerprint">Відбиток пальця</string>
     <string name="add_fingerprint">Додати відбиток пальця</string>
     <string name="place_finger">Помістіть ваш палець на сканер відбитка пальця</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Chèn mẫu hình</string>
     <string name="wrong_pattern">Mẫu hình sai</string>
     <string name="repeat_pattern">Lặp lại mẫu hình</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Vân tay</string>
     <string name="add_fingerprint">Thêm dấu vân tay</string>
     <string name="place_finger">Vui lòng đặt ngón tay của bạn trên cảm biến vân tay</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Vân tay</string>
     <string name="add_fingerprint">Thêm dấu vân tay</string>
     <string name="place_finger">Vui lòng đặt ngón tay của bạn trên cảm biến vân tay</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Quá trình xác thực đã thất bại</string>
     <string name="authentication_blocked">Xác thực bị chặn, vui lòng thử lại sau giây lát</string>
     <string name="no_fingerprints_registered">Bạn chưa đăng ký dấu vân tay, vui lòng thêm trong Cài đặt của thiết bị</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -336,6 +336,8 @@
     <string name="fingerprint">指纹</string>
     <string name="add_fingerprint">添加指纹</string>
     <string name="place_finger">请将手指放在指纹传感器上</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">验证失败</string>
     <string name="authentication_blocked">验证已被阻止，请稍后再试</string>
     <string name="no_fingerprints_registered">您还没有注册指纹，请先给您的设备添加一些指纹</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -333,6 +333,7 @@
     <string name="insert_pattern">绘制图案</string>
     <string name="wrong_pattern">图案错误</string>
     <string name="repeat_pattern">重复图案</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">指纹</string>
     <string name="add_fingerprint">添加指纹</string>
     <string name="place_finger">请将手指放在指纹传感器上</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -336,6 +336,8 @@
     <string name="fingerprint">指紋</string>
     <string name="add_fingerprint">添加指紋</string>
     <string name="place_finger">請將您的手指放置在指紋感應器上</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">驗證失敗</string>
     <string name="authentication_blocked">驗證被限制，請稍後再重試</string>
     <string name="no_fingerprints_registered">你尚未有登錄的指紋，請在裝置的[設定]內添加</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -333,6 +333,7 @@
     <string name="insert_pattern">畫出解鎖圖形</string>
     <string name="wrong_pattern">解鎖圖形錯誤</string>
     <string name="repeat_pattern">再次畫出解鎖圖形</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">指紋</string>
     <string name="add_fingerprint">添加指紋</string>
     <string name="place_finger">請將您的手指放置在指紋感應器上</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -340,6 +340,8 @@
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>
+    <string name="open_biometric_dialog">Open biometric ID verification dialog</string>
+    <string name="authenticate">Authenticate</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="authentication_blocked">Authentication blocked, please try again in a moment</string>
     <string name="no_fingerprints_registered">You have no fingerprints registered, please add some in the Settings of your device</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="insert_pattern">Insert pattern</string>
     <string name="wrong_pattern">Wrong pattern</string>
     <string name="repeat_pattern">Repeat pattern</string>
+    <string name="biometrics">Biometrics</string>
     <string name="fingerprint">Fingerprint</string>
     <string name="add_fingerprint">Add fingerprint</string>
     <string name="place_finger">Please place your finger on the fingerprint sensor</string>


### PR DESCRIPTION
Modifies SecurityDialog to use androidx biometric library if the `targetSdkVersion` is 30+.