### PR TITLE
Add recent colors for color picker dialog

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ColorPickerDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ColorPickerDialog.kt
@@ -168,12 +168,12 @@ class ColorPickerDialog(
         val recentColors = baseConfig.colorPickerRecentColors
         if (recentColors.isNotEmpty()) {
             recent_colors.beVisible()
-            val squareSize = context.resources.getDimensionPixelSize(R.dimen.normal_icon_size)
+            val squareSize = context.resources.getDimensionPixelSize(R.dimen.colorpicker_hue_width)
             recentColors.take(RECENT_COLORS_NUMBER).forEach { recentColor ->
                 val recentColorView = ImageView(context)
                 recentColorView.id = View.generateViewId()
                 recentColorView.layoutParams = ViewGroup.LayoutParams(squareSize, squareSize)
-                recentColorView.setFillWithStroke(recentColor, backgroundColor)
+                recentColorView.setFillWithStroke(recentColor, backgroundColor, cornerRadius)
                 recentColorView.setOnClickListener { newHexField.setText(getHexCode(recentColor)) }
                 recent_colors.addView(recentColorView)
                 recent_colors_flow.addView(recentColorView)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/ImageView.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/ImageView.kt
@@ -10,7 +10,7 @@ fun ImageView.setFillWithStroke(fillColor: Int, backgroundColor: Int, cornerRadi
         shape = GradientDrawable.RECTANGLE
         setColor(fillColor)
         setStroke(2, strokeColor)
-        setBackgroundDrawable(this)
+        background = this
 
         if (cornerRadiusSize != 0f) {
             cornerRadius = cornerRadiusSize

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
@@ -442,4 +442,9 @@ open class BaseConfig(val context: Context) {
     var showCallConfirmation: Boolean
         get() = prefs.getBoolean(SHOW_CALL_CONFIRMATION, false)
         set(showCallConfirmation) = prefs.edit().putBoolean(SHOW_CALL_CONFIRMATION, showCallConfirmation).apply()
+
+    // color picker last used colors
+    internal var colorPickerRecentColors: LinkedList<Int>
+        get() = LinkedList(prefs.getString(COLOR_PICKER_RECENT_COLORS, null)?.lines()?.map { it.toInt() } ?: emptyList())
+        set(recentColors) = prefs.edit().putString(COLOR_PICKER_RECENT_COLORS, recentColors.joinToString(separator = "\n")).apply()
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -150,6 +150,7 @@ const val DEFAULT_TAB = "default_tab"
 const val START_NAME_WITH_SURNAME = "start_name_with_surname"
 const val FAVORITES = "favorites"
 const val SHOW_CALL_CONFIRMATION = "show_call_confirmation"
+internal const val COLOR_PICKER_RECENT_COLORS = "color_picker_recent_colors"
 
 // licenses
 internal const val LICENSE_KOTLIN = 1

--- a/commons/src/main/res/layout/dialog_color_picker.xml
+++ b/commons/src/main/res/layout/dialog_color_picker.xml
@@ -27,7 +27,7 @@
                 app:flow_horizontalGap="@dimen/activity_margin"
                 app:flow_verticalGap="@dimen/medium_margin"
                 app:flow_maxElementsWrap="5"
-                app:flow_wrapMode="aligned"
+                app:flow_wrapMode="chain"
                 app:flow_horizontalStyle="packed"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/commons/src/main/res/layout/dialog_color_picker.xml
+++ b/commons/src/main/res/layout/dialog_color_picker.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/color_picker_scrollview"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,10 +12,34 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/recent_colors"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/activity_margin"
+            android:layout_marginTop="@dimen/activity_margin">
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/recent_colors_flow"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:flow_horizontalAlign="start"
+                app:flow_horizontalGap="@dimen/activity_margin"
+                app:flow_verticalGap="@dimen/medium_margin"
+                app:flow_maxElementsWrap="5"
+                app:flow_wrapMode="aligned"
+                app:flow_horizontalStyle="packed"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <RelativeLayout
             android:id="@+id/color_picker_top_holder"
             android:layout_width="match_parent"
             android:layout_height="@dimen/colorpicker_size_with_padding"
+            android:layout_below="@+id/recent_colors"
             android:gravity="center_horizontal">
 
             <com.simplemobiletools.commons.views.ColorPickerSquare


### PR DESCRIPTION
Store 5 recently used colors for ColorPickerDialog, number is configured by `RECENT_COLORS_NUMBER` in `ColorPickerDialog`.
Client apps need to pass `showRecentColors = true` if they want these colors to be displayed.

![image](https://user-images.githubusercontent.com/7561414/134033475-60dbf444-3fff-4f96-bcd4-33f95008e3bc.png)
