### PR TITLE
Add method to determine if a contact has a particular number

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/models/SimpleContact.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/models/SimpleContact.kt
@@ -44,4 +44,24 @@ data class SimpleContact(val rawId: Int, val contactId: Int, var name: String, v
             false
         }
     }
+
+    fun doesHavePhoneNumber(text: String): Boolean {
+        return if (text.isNotEmpty()) {
+            val normalizedText = text.normalizePhoneNumber()
+            if (normalizedText.isEmpty()) {
+                phoneNumbers.any { phoneNumber ->
+                    phoneNumber == text
+                }
+            } else {
+                phoneNumbers.any { phoneNumber ->
+                    PhoneNumberUtils.compare(phoneNumber.normalizePhoneNumber(), normalizedText) ||
+                        phoneNumber == text ||
+                        phoneNumber.normalizePhoneNumber() == normalizedText ||
+                        phoneNumber == normalizedText
+                }
+            }
+        } else {
+            false
+        }
+    }
 }


### PR DESCRIPTION
- Add `SimpleContact.doesHavePhoneNumber` method to check if a contact has a particular number
- it performs an equality check, so the numbers match exactly
- the method is used on the `Simple SMS Messenger` app to find contacts that match a particular sender's number
- should address this [issue](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/128) in [this](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/pull/211) pull request