### PR TITLE
Implement handling RecoverableSecurityException 

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -1194,7 +1194,7 @@ fun AppCompatActivity.showSideloadingDialog() {
 }
 
 fun BaseSimpleActivity.getTempFile(folderName: String, fileName: String): File? {
-    val folder = File(cacheDir, fileName)
+    val folder = File(cacheDir, folderName)
     if (!folder.exists()) {
         if (!folder.mkdir()) {
             toast(R.string.unknown_error_occurred)


### PR DESCRIPTION
**Notes**
- Implement handling `RecoverableSecurityException`  needed for updating files in `MediaStore` 
- fix `getTempFile` method, use `folderName` parameter
- needed to solve[ this issue](https://github.com/SimpleMobileTools/Simple-Music-Player/issues/298)
- this functionality is needed in the [Simple Music Player](https://github.com/SimpleMobileTools/Simple-Music-Player/pull/353) app. 