### PR TITLE
change ViewHolder's viewClicked and viewLongClicked to public methods

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewAdapter.kt
@@ -313,7 +313,7 @@ abstract class MyRecyclerViewAdapter(val activity: BaseSimpleActivity, val recyc
             }
         }
 
-        private fun viewClicked(any: Any) {
+        fun viewClicked(any: Any) {
             if (actModeCallback.isSelectable) {
                 val currentPosition = adapterPosition - positionOffset
                 val isSelected = selectedKeys.contains(getItemSelectionKey(currentPosition))
@@ -324,7 +324,7 @@ abstract class MyRecyclerViewAdapter(val activity: BaseSimpleActivity, val recyc
             lastLongPressedItem = -1
         }
 
-        private fun viewLongClicked() {
+        fun viewLongClicked() {
             val currentPosition = adapterPosition - positionOffset
             if (!actModeCallback.isSelectable) {
                 activity.startSupportActionMode(actModeCallback)


### PR DESCRIPTION
 **Notes**
 - change `ViewHolder`'s `viewClicked` and `viewLongClicked` to public methods
 - this is required because some apps may want to trigger these events from another view
 - it is used in the [SMS Messenger](https://github.com/SimpleMobileTools/Simple-SMS-Messenger) app to trigger a long click to select from clicking the message bubble
 - part of the PRs to address [this issue](https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/139)