### PR TITLE
Fixed contact padding

### DIFF
--- a/commons/src/main/res/layout/item_contact_with_number.xml
+++ b/commons/src/main/res/layout/item_contact_with_number.xml
@@ -13,6 +13,7 @@
         android:id="@+id/item_contact_holder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/tiny_margin"
         android:paddingTop="@dimen/medium_margin"
         android:paddingEnd="@dimen/activity_margin"
         android:paddingBottom="@dimen/medium_margin">
@@ -23,8 +24,7 @@
             android:layout_height="@dimen/normal_icon_size"
             android:layout_centerVertical="true"
             android:layout_marginStart="@dimen/small_margin"
-            android:layout_marginEnd="@dimen/small_margin"
-            android:padding="@dimen/small_margin"
+            android:padding="@dimen/tiny_margin"
             android:src="@drawable/ic_person_vector" />
 
         <TextView

--- a/commons/src/main/res/layout/item_contact_with_number.xml
+++ b/commons/src/main/res/layout/item_contact_with_number.xml
@@ -33,7 +33,9 @@
             android:layout_height="wrap_content"
             android:layout_toEndOf="@+id/item_contact_image"
             android:ellipsize="end"
+            android:gravity="center_vertical"
             android:maxLines="1"
+            android:paddingStart="@dimen/medium_margin"
             android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/big_text_size"
             tools:text="John Doe" />
@@ -45,8 +47,11 @@
             android:layout_below="@+id/item_contact_name"
             android:layout_alignStart="@+id/item_contact_name"
             android:layout_toEndOf="@+id/item_contact_image"
+            android:gravity="center_vertical"
             android:alpha="0.6"
             android:maxLines="1"
+            android:paddingStart="@dimen/medium_margin"
+            android:paddingEnd="@dimen/activity_margin"
             android:textSize="@dimen/normal_text_size"
             tools:text="0123 456 789" />
 


### PR DESCRIPTION
Hi,

I've found in Simple Contacts, that when you hide contact thumbnail and show number, there is no margin between the side of the screen and text. I did the same paddings as there are for contacts without displaying phone number.

**Before:**

![Screenshot_2](https://user-images.githubusercontent.com/85929121/143958065-35f0ec41-581e-4c96-8b70-58784c8d2a2c.png)

**After:**

![Screenshot_1](https://user-images.githubusercontent.com/85929121/143958077-f8af96f9-88e9-48ee-9f47-18842f59e2a3.png)


