### PR TITLE
Add ChecksSdkIntAtLeast to Sdk version checks

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Looper
 import android.util.Log
+import androidx.annotation.ChecksSdkIntAtLeast
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.overloads.times
 import java.util.HashMap
@@ -371,13 +372,21 @@ fun ensureBackgroundThread(callback: () -> Unit) {
     }
 }
 
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.M)
 fun isMarshmallowPlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N)
 fun isNougatPlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.N_MR1)
 fun isNougatMR1Plus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O)
 fun isOreoPlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.O_MR1)
 fun isOreoMr1Plus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.P)
 fun isPiePlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.Q)
 fun isQPlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+@ChecksSdkIntAtLeast(api = Build.VERSION_CODES.R)
 fun isRPlus() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 
 fun getDateFormats() = arrayListOf(


### PR DESCRIPTION
The linter is able to infer this inside a project but
in order to make it work more reliably cross project
it is better to make it explicit.

Found this is needed on https://github.com/SimpleMobileTools/Simple-Clock/blob/c812483f132eb3a8d67f1c481e7e3399c77b7a7e/app/src/main/kotlin/com/simplemobiletools/clock/services/TimerService.kt#L94 where `isOreoPlus` is stated by liner can't understand it thus `@TargetApi(Build.VERSION_CODES.O)` is used to silence the complain.