### PR TITLE
fix: clipped popup on android 9

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/bottomactionmenu/BottomActionMenuView.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/bottomactionmenu/BottomActionMenuView.kt
@@ -14,7 +14,10 @@ import android.widget.LinearLayout
 import androidx.annotation.IdRes
 import com.google.android.material.animation.AnimationUtils
 import com.simplemobiletools.commons.R
-import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.extensions.applyColorFilter
+import com.simplemobiletools.commons.extensions.beVisibleIf
+import com.simplemobiletools.commons.extensions.toast
+import com.simplemobiletools.commons.extensions.windowManager
 import com.simplemobiletools.commons.helpers.isRPlus
 
 class BottomActionMenuView : LinearLayout {
@@ -40,6 +43,7 @@ class BottomActionMenuView : LinearLayout {
 
     private var currentAnimator: ViewPropertyAnimator? = null
     private var callback: BottomActionMenuCallback? = null
+    private var itemPopup: BottomActionMenuItemPopup? = null
 
     init {
         orientation = HORIZONTAL
@@ -151,7 +155,11 @@ class BottomActionMenuView : LinearLayout {
         (inflater.inflate(R.layout.item_action_mode, this, false) as ImageView).apply {
             setupItem(item)
             setOnClickListener {
-                callback?.onItemClicked(item)
+                if (itemPopup?.isShowing == true) {
+                    itemPopup?.dismiss()
+                } else {
+                    callback?.onItemClicked(item)
+                }
             }
             setOnLongClickListener {
                 context.toast(item.title)
@@ -167,9 +175,13 @@ class BottomActionMenuView : LinearLayout {
             val contentDesc = context.getString(R.string.more_info)
             contentDescription = contentDesc
             applyColorFilter(Color.WHITE)
-            val popup = getOverflowPopup(overFlowItems)
+            itemPopup = getOverflowPopup(overFlowItems)
             setOnClickListener {
-                popup.show(it)
+                if (itemPopup?.isShowing == true) {
+                    itemPopup?.dismiss()
+                } else {
+                    itemPopup?.show(it)
+                }
             }
             setOnLongClickListener {
                 context.toast(contentDesc)


### PR DESCRIPTION
**Notes**
- fix clipped popup on android 9
- for some weird reasons, the previous way of showing the bottom menu item popup with Popup#showAsDropDown passing in a view in the bottom menu popup, caused the item popup to be clipped on android 9, other android versions worked fine. 
- this pull request attempts to fix the clipping by using Popup#showAtLocation, passing in the popup's content view which has a window token tied to the activity view hierarchy, and with some position calculations to show the popup at the bottom, right (end) on top of the bottom menu popup. 

Before: 

https://user-images.githubusercontent.com/25648077/149052448-db4d0fe5-fb46-486a-8609-ea67e1bbd355.mp4


After:

https://user-images.githubusercontent.com/25648077/149052507-66cf95b5-4a55-42bc-986e-c8c4ae1d50fa.mp4


