### PR TITLE
Make left arrow icon auto-mirrored

### DIFF
--- a/commons/src/main/res/drawable/ic_arrow_left_vector.xml
+++ b/commons/src/main/res/drawable/ic_arrow_left_vector.xml
@@ -1,3 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24" android:autoMirrored="true">
     <path android:fillColor="#FFFFFFFF" android:pathData="M19 11H7.83l4.88-4.88c0.39-0.39 0.39-1.03 0-1.42-0.39-0.39-1.02-0.39-1.41 0l-6.59 6.59c-0.39 0.39-0.39 1.02 0 1.41l6.59 6.59c0.39 0.39 1.02 0.39 1.41 0 0.39-0.39 0.39-1.02 0-1.41L7.83 13H19c0.55 0 1-0.45 1-1s-0.45-1-1-1z"/>
 </vector>


### PR DESCRIPTION
Should fix https://github.com/SimpleMobileTools/Simple-Gallery/issues/2206, but I have not tested yet, hence this being a draft.

Is auto-mirroring an icon with `left` in its name a good idea? What do you think?