### PR TITLE
fix renamed  leaves a empty file in media store

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -841,6 +841,7 @@ fun BaseSimpleActivity.renameFile(
                     runOnUiThread {
                         callback?.invoke(true, false)
                     }
+                    deleteFromMediaStore(oldPath)
                     scanPathRecursively(newPath)
                 }
             } else {
@@ -849,6 +850,7 @@ fun BaseSimpleActivity.renameFile(
                 }
                 updateInMediaStore(oldPath, newPath)
                 scanPathsRecursively(arrayListOf(newPath)) {
+                    deleteFromMediaStore(oldPath)
                     runOnUiThread {
                         callback?.invoke(true, false)
                     }


### PR DESCRIPTION
**Notes**
- should fix [this issue in File Manager](https://github.com/SimpleMobileTools/Simple-File-Manager/issues/544)
- should fix [this issue in Gallery](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2307)

**Before**

https://user-images.githubusercontent.com/25648077/149683258-6bde3507-632e-4a57-988a-f1cbee167bd7.mp4


**After**

https://user-images.githubusercontent.com/25648077/149683266-956d9aa8-43d9-4959-aed9-e7ada6500677.mp4



