### PR TITLE
change needsStupidWritePermissions to return false for devices >= API 30

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage.kt
@@ -170,7 +170,7 @@ fun Context.isRestrictedSAFOnlyRoot(path: String): Boolean {
 }
 
 // no need to use DocumentFile if an SD card is set as the default storage
-fun Context.needsStupidWritePermissions(path: String) = (isPathOnSD(path) || isPathOnOTG(path)) && !isSDCardSetAsDefaultStorage()
+fun Context.needsStupidWritePermissions(path: String) = !isRPlus() && (isPathOnSD(path) || isPathOnOTG(path)) && !isSDCardSetAsDefaultStorage()
 
 fun Context.isSDCardSetAsDefaultStorage() = sdCardPath.isNotEmpty() && Environment.getExternalStorageDirectory().absolutePath.equals(sdCardPath, true)
 


### PR DESCRIPTION
**Notes**
- Android allows apps to modify media files with the File API as long as they have the `READ_EXTERNAL_STORAGE` permission [reference](https://developer.android.com/training/data-storage/shared/media#direct-file-paths)
- should fix issues with creating folders on >= API 30 on the File Manager app on allowed directories when the `MANAGE_EXTERNAL_STORAGE` permission is granted and the File APIs can be used
- closes [this issue in Simple Gallery](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2326)
- closes [this issue in Simple File Manager](https://github.com/SimpleMobileTools/Simple-File-Manager/issues/551)

---
**Simple Gallery fix**
**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/150678758-2ba4d78f-3ade-4d0c-b551-c7e1deac1849.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/150678991-fb6b440c-64e3-4e86-bea7-e200a81ab78d.mp4" width="320"/>


---
**Simple File Manager fix**
**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/150680314-bf012bdf-8952-440a-bf77-1923b6629cce.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/150679378-7aaffd90-5036-46f9-9cab-0fffa1b77776.mp4" width="320"/>






