### PR TITLE
Revert from using the bottom action menu

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerFavoritesAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerFavoritesAdapter.kt
@@ -1,13 +1,13 @@
 package com.simplemobiletools.commons.adapters
 
 import android.util.TypedValue
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.getTextSize
 import com.simplemobiletools.commons.views.MyRecyclerView
-import com.simplemobiletools.commons.views.bottomactionmenu.BottomActionMenuView
 import kotlinx.android.synthetic.main.filepicker_favorite.view.*
 
 class FilepickerFavoritesAdapter(
@@ -35,7 +35,7 @@ class FilepickerFavoritesAdapter(
 
     override fun getItemCount() = paths.size
 
-    override fun onBottomActionMenuCreated(view: BottomActionMenuView) {}
+    override fun prepareActionMode(menu: Menu) {}
 
     override fun actionItemPressed(id: Int) {}
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerItemsAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/FilepickerItemsAdapter.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.commons.adapters
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.util.TypedValue
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import com.bumptech.glide.Glide
@@ -18,7 +19,6 @@ import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.getFilePlaceholderDrawables
 import com.simplemobiletools.commons.models.FileDirItem
 import com.simplemobiletools.commons.views.MyRecyclerView
-import com.simplemobiletools.commons.views.bottomactionmenu.BottomActionMenuView
 import kotlinx.android.synthetic.main.item_filepicker_list.view.*
 import java.util.*
 
@@ -55,7 +55,7 @@ class FilepickerItemsAdapter(
 
     override fun getItemCount() = fileDirItems.size
 
-    override fun onBottomActionMenuCreated(view: BottomActionMenuView) {}
+    override fun prepareActionMode(menu: Menu) {}
 
     override fun actionItemPressed(id: Int) {}
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/ManageBlockedNumbersAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/ManageBlockedNumbersAdapter.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.commons.adapters
 
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import com.simplemobiletools.commons.R
@@ -9,7 +10,6 @@ import com.simplemobiletools.commons.extensions.deleteBlockedNumber
 import com.simplemobiletools.commons.interfaces.RefreshRecyclerViewListener
 import com.simplemobiletools.commons.models.BlockedNumber
 import com.simplemobiletools.commons.views.MyRecyclerView
-import com.simplemobiletools.commons.views.bottomactionmenu.BottomActionMenuView
 import kotlinx.android.synthetic.main.item_manage_blocked_number.view.*
 import java.util.*
 
@@ -23,8 +23,10 @@ class ManageBlockedNumbersAdapter(
 
     override fun getActionMenuId() = R.menu.cab_blocked_numbers
 
-    override fun onBottomActionMenuCreated(view: BottomActionMenuView) {
-        view.toggleItemVisibility(R.id.cab_copy_number, isOneItemSelected())
+    override fun prepareActionMode(menu: Menu) {
+        menu.apply {
+            findItem(R.id.cab_copy_number).isVisible = isOneItemSelected()
+        }
     }
 
     override fun actionItemPressed(id: Int) {


### PR DESCRIPTION
**Notes**
- This revert from using the previously added bottom action menu. 
- Apps will now use the top contextual action menu
- This is done because the bottom action menu implementation is not complete yet and apps need to be updated