### PR TITLE
Renaming on SDK 30+

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FilePickerDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FilePickerDialog.kt
@@ -207,6 +207,15 @@ class FilePickerDialog(
             if ((pickFile && fileDocument.isFile) || (!pickFile && fileDocument.isDirectory)) {
                 sendSuccess()
             }
+        } else if (activity.isAccessibleWithSAFSdk30(currPath)) {
+            activity.handleSAFDialogSdk30(currPath) {
+                if (it) {
+                    val document = activity.getSomeDocumentSdk30(currPath) ?: return@handleSAFDialogSdk30
+                    if ((pickFile && document.isFile) || (!pickFile && document.isDirectory)) {
+                        sendSuccess()
+                    }
+                }
+            }
         } else {
             val file = File(currPath)
             if ((pickFile && file.isFile) || (!pickFile && file.isDirectory)) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity-sdk30.kt
@@ -1,0 +1,74 @@
+package com.simplemobiletools.commons.extensions
+
+import android.content.ContentValues
+import android.provider.MediaStore
+import com.simplemobiletools.commons.R
+import com.simplemobiletools.commons.activities.BaseSimpleActivity
+import com.simplemobiletools.commons.models.FileDirItem
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+
+fun BaseSimpleActivity.copySingleFileSdk30(source: FileDirItem, destination: FileDirItem): Boolean {
+    val directory = destination.getParentPath()
+    if (!createDirectorySync(directory)) {
+        val error = String.format(getString(R.string.could_not_create_folder), directory)
+        showErrorToast(error)
+        return false
+    }
+
+    var inputStream: InputStream? = null
+    var out: OutputStream? = null
+    try {
+
+        out = getFileOutputStreamSync(destination.path, source.path.getMimeType())
+        inputStream = getFileInputStreamSync(source.path)!!
+
+        var copiedSize = 0L
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var bytes = inputStream.read(buffer)
+        while (bytes >= 0) {
+            out!!.write(buffer, 0, bytes)
+            copiedSize += bytes
+            bytes = inputStream.read(buffer)
+        }
+
+        out?.flush()
+
+        return if (source.size == copiedSize && getDoesFilePathExist(destination.path)) {
+            if (baseConfig.keepLastModified) {
+                copyOldLastModified(source.path, destination.path)
+                File(destination.path).setLastModified(File(source.path).lastModified())
+            }
+            true
+        } else {
+            false
+        }
+    } finally {
+        inputStream?.close()
+        out?.close()
+    }
+}
+
+fun BaseSimpleActivity.copyOldLastModified(sourcePath: String, destinationPath: String) {
+    val projection = arrayOf(MediaStore.Images.Media.DATE_TAKEN, MediaStore.Images.Media.DATE_MODIFIED)
+    val uri = MediaStore.Files.getContentUri("external")
+    val selection = "${MediaStore.MediaColumns.DATA} = ?"
+    var selectionArgs = arrayOf(sourcePath)
+    val cursor = applicationContext.contentResolver.query(uri, projection, selection, selectionArgs, null)
+
+    cursor?.use {
+        if (cursor.moveToFirst()) {
+            val dateTaken = cursor.getLongValue(MediaStore.Images.Media.DATE_TAKEN)
+            val dateModified = cursor.getIntValue(MediaStore.Images.Media.DATE_MODIFIED)
+
+            val values = ContentValues().apply {
+                put(MediaStore.Images.Media.DATE_TAKEN, dateTaken)
+                put(MediaStore.Images.Media.DATE_MODIFIED, dateModified)
+            }
+
+            selectionArgs = arrayOf(destinationPath)
+            applicationContext.contentResolver.update(uri, values, selection, selectionArgs)
+        }
+    }
+}

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -860,7 +860,6 @@ fun BaseSimpleActivity.renameFile(
             }
         }
     } else if (isAccessibleWithSAFSdk30(oldPath)) {
-
         handleSAFDialogSdk30(oldPath) {
             if (!it) {
                 return@handleSAFDialogSdk30

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -834,26 +834,49 @@ fun BaseSimpleActivity.renameFile(
     oldPath: String,
     newPath: String,
     isRenamingMultipleFiles: Boolean,
-    callback: ((success: Boolean, useAndroid30Way: Boolean) -> Unit)? = null
+    callback: ((success: Boolean, android30RenameFormat: Android30RenameFormat) -> Unit)? = null
 ) {
     if (isRestrictedSAFOnlyRoot(oldPath)) {
         handleAndroidSAFDialog(oldPath) {
             if (!it) {
                 runOnUiThread {
-                    callback?.invoke(false, false)
+                    callback?.invoke(false, Android30RenameFormat.NONE)
                 }
                 return@handleAndroidSAFDialog
             }
 
             try {
-                val success = renameAndroidSAFDocument(oldPath, newPath)
-                runOnUiThread {
-                    callback?.invoke(success, false)
+                ensureBackgroundThread {
+                    val success = renameAndroidSAFDocument(oldPath, newPath)
+                    runOnUiThread {
+                        callback?.invoke(success, Android30RenameFormat.NONE)
+                    }
                 }
             } catch (e: Exception) {
                 showErrorToast(e)
                 runOnUiThread {
-                    callback?.invoke(false, false)
+                    callback?.invoke(false, Android30RenameFormat.NONE)
+                }
+            }
+        }
+    } else if (isAccessibleWithSAFSdk30(oldPath)) {
+
+        handleSAFDialogSdk30(oldPath) {
+            if (!it) {
+                return@handleSAFDialogSdk30
+            }
+
+            try {
+                ensureBackgroundThread {
+                    val success = renameDocumentSdk30(oldPath, newPath)
+                    runOnUiThread {
+                        callback?.invoke(success, Android30RenameFormat.NONE)
+                    }
+                }
+            } catch (e: Exception) {
+                showErrorToast(e)
+                runOnUiThread {
+                    callback?.invoke(false, Android30RenameFormat.NONE)
                 }
             }
         }
@@ -866,7 +889,7 @@ fun BaseSimpleActivity.renameFile(
             val document = getSomeDocumentFile(oldPath)
             if (document == null || (File(oldPath).isDirectory != document.isDirectory)) {
                 runOnUiThread {
-                    callback?.invoke(false, false)
+                    callback?.invoke(false, Android30RenameFormat.NONE)
                 }
                 return@handleSAFDialog
             }
@@ -879,7 +902,7 @@ fun BaseSimpleActivity.renameFile(
                         // FileNotFoundException is thrown in some weird cases, but renaming works just fine
                     } catch (e: Exception) {
                         showErrorToast(e)
-                        callback?.invoke(false, false)
+                        callback?.invoke(false, Android30RenameFormat.NONE)
                         return@ensureBackgroundThread
                     }
 
@@ -890,14 +913,14 @@ fun BaseSimpleActivity.renameFile(
                         }
                         deleteFromMediaStore(oldPath)
                         runOnUiThread {
-                            callback?.invoke(true, false)
+                            callback?.invoke(true, Android30RenameFormat.NONE)
                         }
                     }
                 }
             } catch (e: Exception) {
                 showErrorToast(e)
                 runOnUiThread {
-                    callback?.invoke(false, false)
+                    callback?.invoke(false, Android30RenameFormat.NONE)
                 }
             }
         }
@@ -910,7 +933,7 @@ fun BaseSimpleActivity.renameFile(
             if (isRPlus() && exception is java.nio.file.FileSystemException) {
                 // if we are renaming multiple files at once, we should give the Android 30+ permission dialog all uris together, not one by one
                 if (isRenamingMultipleFiles) {
-                    callback?.invoke(false, true)
+                    callback?.invoke(false, Android30RenameFormat.CONTENT_RESOLVER)
                 } else {
                     val fileUris = getFileUrisFromFileDirItems(arrayListOf(File(oldPath).toFileDirItem(this))).second
                     updateSDK30Uris(fileUris) { success ->
@@ -921,19 +944,19 @@ fun BaseSimpleActivity.renameFile(
 
                             try {
                                 contentResolver.update(fileUris.first(), values, null, null)
-                                callback?.invoke(true, false)
+                                callback?.invoke(true, Android30RenameFormat.NONE)
                             } catch (e: Exception) {
                                 showErrorToast(e)
-                                callback?.invoke(false, false)
+                                callback?.invoke(false, Android30RenameFormat.NONE)
                             }
                         } else {
-                            callback?.invoke(false, false)
+                            callback?.invoke(false, Android30RenameFormat.NONE)
                         }
                     }
                 }
             } else {
                 showErrorToast(exception)
-                callback?.invoke(false, false)
+                callback?.invoke(false, Android30RenameFormat.NONE)
             }
             return
         }
@@ -945,7 +968,7 @@ fun BaseSimpleActivity.renameFile(
                 updateInMediaStore(oldPath, newPath)
                 rescanPath(newPath) {
                     runOnUiThread {
-                        callback?.invoke(true, false)
+                        callback?.invoke(true, Android30RenameFormat.NONE)
                     }
                     deleteFromMediaStore(oldPath)
                     scanPathRecursively(newPath)
@@ -958,14 +981,48 @@ fun BaseSimpleActivity.renameFile(
                 scanPathsRecursively(arrayListOf(newPath)) {
                     deleteFromMediaStore(oldPath)
                     runOnUiThread {
-                        callback?.invoke(true, false)
+                        callback?.invoke(true, Android30RenameFormat.NONE)
                     }
                 }
             }
         } else {
             tempFile.delete()
-            runOnUiThread {
-                callback?.invoke(false, false)
+            newFile.delete()
+            if (isRPlus()) {
+                // if we are renaming multiple files at once, we should give the Android 30+ permission dialog all uris together, not one by one
+                if (isRenamingMultipleFiles) {
+                    callback?.invoke(false, Android30RenameFormat.SAF)
+                } else {
+                    val fileUris = getFileUrisFromFileDirItems(arrayListOf(File(oldPath).toFileDirItem(this))).second
+                    updateSDK30Uris(fileUris) { success ->
+                        if (!success) {
+                            return@updateSDK30Uris
+                        }
+                        try {
+                            val sourceFile = File(oldPath).toFileDirItem(this)
+                            val destinationFile = sourceFile.copy(path = newPath, name = newPath.getFilenameFromPath())
+                            val copySuccessful = copySingleFileSdk30(sourceFile, destinationFile)
+                            if (copySuccessful) {
+                                if (!baseConfig.keepLastModified) {
+                                    newFile.setLastModified(System.currentTimeMillis())
+                                }
+                                contentResolver.delete(fileUris.first(), null)
+                                updateInMediaStore(oldPath, newPath)
+                                scanPathsRecursively(arrayListOf(newPath)) {
+                                    runOnUiThread {
+                                        callback?.invoke(true, Android30RenameFormat.NONE)
+                                    }
+                                }
+                            }
+
+                        } catch (e: Exception) {
+                            showErrorToast(e)
+                            callback?.invoke(false, Android30RenameFormat.NONE)
+                        }
+                    }
+                }
+            } else {
+                callback?.invoke(false, Android30RenameFormat.NONE)
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
@@ -153,6 +153,18 @@ fun Context.deleteDocumentWithSAFSdk30(fileDirItem: FileDirItem, allowDeleteFold
     }
 }
 
+fun Context.renameDocumentSdk30(oldPath: String, newPath: String): Boolean {
+    return try {
+        val treeUri = createFirstParentTreeUri(oldPath)
+        val documentId = getSAFDocumentId(oldPath)
+        val parentUri = DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
+        DocumentsContract.renameDocument(contentResolver, parentUri, newPath.getFilenameFromPath()) != null
+    } catch (e: IllegalStateException) {
+        showErrorToast(e)
+        false
+    }
+}
+
 fun Context.hasProperStoredDocumentUriSdk30(path: String): Boolean {
     val documentUri = buildDocumentUriSdk30(path)
     return contentResolver.persistedUriPermissions.any { it.uri.toString() == documentUri.toString() }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/models/Android30RenameFormat.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/models/Android30RenameFormat.kt
@@ -1,0 +1,7 @@
+package com.simplemobiletools.commons.models
+
+enum class Android30RenameFormat {
+    SAF,
+    CONTENT_RESOLVER,
+    NONE
+}

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/models/FileDirItem.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/models/FileDirItem.kt
@@ -7,7 +7,7 @@ import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.*
 import java.io.File
 
-open class FileDirItem(
+data class FileDirItem(
     val path: String,
     val name: String = "",
     var isDirectory: Boolean = false,


### PR DESCRIPTION
## Notes
- handle renaming files with SAF except for files in the `Download` directory
- handle renaming files in the `Download` directory using `MediaStore.createWriteRequest`, then duplicating the file with the new name
- handle renaming files in the root of internal storage using `MediaStore.createWriteRequest`, then using `contentResolver` to update the display name
- these methods do not work for files in the root of SD card and all files in OTG media

Testing on [Android 11](https://lumpy-scorpion-7f2.notion.site/3bd3976013b94cf9b725d17a42e8121c?v=e1e317f9133c4dcf945c98cb58af602e) and [Android 12](https://lumpy-scorpion-7f2.notion.site/5b9cecae97aa4c86ba8409f774a77bd6?v=22eee96ab74b484784e2427699dbcef4)