### PR TITLE
sdk 30 changes

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -491,7 +491,7 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
         }
 
         funAfterSAFPermission = callback
-        WritePermissionDialog(this, Mode.OTG) {
+        WritePermissionDialog(this, Mode.Otg) {
             Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                 try {
                     startActivityForResult(this, OPEN_DOCUMENT_TREE_OTG)
@@ -593,11 +593,7 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                     ) {
                         handleSAFDialog(source) {
                             if (it) {
-                                handleSAFDialogSdk30(source) {
-                                    if (it) {
-                                        startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
-                                    }
-                                }
+                                startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
                             }
                         }
                     } else {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/WritePermissionDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/WritePermissionDialog.kt
@@ -11,39 +11,39 @@ import kotlinx.android.synthetic.main.dialog_write_permission.view.*
 import kotlinx.android.synthetic.main.dialog_write_permission_otg.view.*
 
 class WritePermissionDialog(activity: Activity, val mode: Mode, val callback: () -> Unit) {
-    enum class Mode {
-        OTG,
-        SD_CARD,
-        OPEN_DOCUMENT_TREE_SDK_30,
-        CREATE_DOCUMENT_SDK_30,
+    sealed class Mode {
+        object Otg : Mode()
+        object SdCard : Mode()
+        data class OpenDocumentTreeSDK30(val path: String) : Mode()
+        object CreateDocumentSDK30 : Mode()
     }
 
     var dialog: AlertDialog
 
     init {
-        val layout = if (mode == Mode.SD_CARD) R.layout.dialog_write_permission else R.layout.dialog_write_permission_otg
+        val layout = if (mode == Mode.SdCard) R.layout.dialog_write_permission else R.layout.dialog_write_permission_otg
         val view = activity.layoutInflater.inflate(layout, null)
 
         val glide = Glide.with(activity)
         val crossFade = DrawableTransitionOptions.withCrossFade()
         when (mode) {
-            Mode.OTG -> {
+            Mode.Otg -> {
                 view.write_permissions_dialog_otg_text.setText(R.string.confirm_usb_storage_access_text)
                 glide.load(R.drawable.img_write_storage_otg).transition(crossFade).into(view.write_permissions_dialog_otg_image)
             }
-            Mode.SD_CARD -> {
+            Mode.SdCard -> {
                 glide.load(R.drawable.img_write_storage).transition(crossFade).into(view.write_permissions_dialog_image)
                 glide.load(R.drawable.img_write_storage_sd).transition(crossFade).into(view.write_permissions_dialog_image_sd)
             }
-            Mode.OPEN_DOCUMENT_TREE_SDK_30 -> {
-                view.write_permissions_dialog_otg_text.setText(R.string.confirm_storage_access_android_text)
+            is Mode.OpenDocumentTreeSDK30 -> {
+                view.write_permissions_dialog_otg_text.text = activity.getString(R.string.confirm_storage_access_android_text_specific, mode.path)
                 glide.load(R.drawable.img_write_storage_sdk_30).transition(crossFade).into(view.write_permissions_dialog_otg_image)
 
                 view.write_permissions_dialog_otg_image.setOnClickListener {
                     dialogConfirmed()
                 }
             }
-            Mode.CREATE_DOCUMENT_SDK_30 -> {
+            Mode.CreateDocumentSDK30 -> {
                 view.write_permissions_dialog_otg_text.setText(R.string.confirm_create_doc_for_new_folder_text)
                 glide.load(R.drawable.img_write_storage_create_doc_sdk_30).transition(crossFade).into(view.write_permissions_dialog_otg_image)
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -125,7 +125,7 @@ fun BaseSimpleActivity.isShowingSAFDialog(path: String): Boolean {
     return if ((!isRPlus() && isPathOnSD(path) && !isSDCardSetAsDefaultStorage() && (baseConfig.sdTreeUri.isEmpty() || !hasProperStoredTreeUri(false)))) {
         runOnUiThread {
             if (!isDestroyed && !isFinishing) {
-                WritePermissionDialog(this, Mode.SD_CARD) {
+                WritePermissionDialog(this, Mode.SdCard) {
                     Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                         putExtra(EXTRA_SHOW_ADVANCED, true)
                         try {
@@ -157,7 +157,7 @@ fun BaseSimpleActivity.isShowingSAFDialogSdk30(path: String): Boolean {
     return if (isAccessibleWithSAFSdk30(path) && !hasProperStoredFirstParentUri(path)) {
         runOnUiThread {
             if (!isDestroyed && !isFinishing) {
-                WritePermissionDialog(this, Mode.OPEN_DOCUMENT_TREE_SDK_30) {
+                WritePermissionDialog(this, Mode.OpenDocumentTreeSDK30(path.getFirstParentPath(this))) {
                     Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                         putExtra(EXTRA_SHOW_ADVANCED, true)
                         putExtra(DocumentsContract.EXTRA_INITIAL_URI, createFirstParentTreeUriUsingRootTree(path))
@@ -190,7 +190,7 @@ fun BaseSimpleActivity.isShowingSAFCreateDocumentDialogSdk30(path: String): Bool
     return if (!hasProperStoredDocumentUriSdk30(path)) {
         runOnUiThread {
             if (!isDestroyed && !isFinishing) {
-                WritePermissionDialog(this, Mode.CREATE_DOCUMENT_SDK_30) {
+                WritePermissionDialog(this, Mode.CreateDocumentSDK30) {
                     Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
                         type = DocumentsContract.Document.MIME_TYPE_DIR
                         putExtra(EXTRA_SHOW_ADVANCED, true)
@@ -267,7 +267,7 @@ fun BaseSimpleActivity.isShowingOTGDialog(path: String): Boolean {
 fun BaseSimpleActivity.showOTGPermissionDialog(path: String) {
     runOnUiThread {
         if (!isDestroyed && !isFinishing) {
-            WritePermissionDialog(this, Mode.OTG) {
+            WritePermissionDialog(this, Mode.Otg) {
                 Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                     try {
                         startActivityForResult(this, OPEN_DOCUMENT_TREE_OTG)


### PR DESCRIPTION
## Changes
- remove `handleSAFDialogSdk30` for source paths since we have READ permission
- display the desired path in `WritePermissionDialog` for selecting tree URI on SDK 30+

https://user-images.githubusercontent.com/25648077/159136292-d333126e-dde2-486d-8286-a0395e4a8ec5.mp4


