### PR TITLE
fix: renaming with just case changing

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -969,7 +969,9 @@ fun BaseSimpleActivity.renameFile(
                     runOnUiThread {
                         callback?.invoke(true, Android30RenameFormat.NONE)
                     }
-                    deleteFromMediaStore(oldPath)
+                    if (!oldPath.equals(newPath, true)) {
+                        deleteFromMediaStore(oldPath)
+                    }
                     scanPathRecursively(newPath)
                 }
             } else {
@@ -978,7 +980,9 @@ fun BaseSimpleActivity.renameFile(
                 }
                 updateInMediaStore(oldPath, newPath)
                 scanPathsRecursively(arrayListOf(newPath)) {
-                    deleteFromMediaStore(oldPath)
+                    if (!oldPath.equals(newPath, true)) {
+                        deleteFromMediaStore(oldPath)
+                    }
                     runOnUiThread {
                         callback?.invoke(true, Android30RenameFormat.NONE)
                     }


### PR DESCRIPTION
## Notes
 - The MediaStore DATA column is case insensitive so renaming files with just a change in the casing of the file name still points to the same DATA column from the MediaStore’s perspective.

- So we do not need to delete the old path from MediaStore if it’s just the casing changed in the file name.