### PR TITLE
fix: overwriting files on SD card

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -1162,7 +1162,7 @@ fun BaseSimpleActivity.getFileOutputStreamSync(path: String, mimeType: String, p
             }
 
             try {
-                val newDocument = documentFile.createFile(mimeType, path.getFilenameFromPath()) ?: getDocumentFile(path)
+                val newDocument = getDocumentFile(path) ?: documentFile.createFile(mimeType, path.getFilenameFromPath())
                 applicationContext.contentResolver.openOutputStream(newDocument!!.uri)
             } catch (e: Exception) {
                 showErrorToast(e)


### PR DESCRIPTION
## Notes
- fix overwriting files on SD card on Android 10
- closes [this issue](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2382) on Simple Gallery App

**Simple File Manager fix**
**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/159575980-8c68671a-fa03-40ae-a177-3ac7b9b9f0df.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/159576232-b1ec379b-1742-4332-819c-d7f945a52e33.mp4" width="320"/>







