### PR TITLE
feat: SAF on 30+ for Download and Android folders

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -270,7 +270,9 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                 val checkedUri = createFirstParentTreeUri(checkedDocumentPath)
 
                 if (treeUri != checkedUri) {
-                    toast(getString(R.string.wrong_folder_selected, checkedDocumentPath.getFirstParentPath(this)))
+                    val level = getFirstParentLevel(checkedDocumentPath)
+                    val firstParentPath = checkedDocumentPath.getFirstParentPath(this, level)
+                    toast(getString(R.string.wrong_folder_selected, humanizePath(firstParentPath)))
                     return
                 }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -171,7 +171,8 @@ fun BaseSimpleActivity.isShowingSAFDialogSdk30(path: String): Boolean {
     return if (isAccessibleWithSAFSdk30(path) && !hasProperStoredFirstParentUri(path)) {
         runOnUiThread {
             if (!isDestroyed && !isFinishing) {
-                WritePermissionDialog(this, Mode.OpenDocumentTreeSDK30(path.getFirstParentPath(this))) {
+                val level = getFirstParentLevel(path)
+                WritePermissionDialog(this, Mode.OpenDocumentTreeSDK30(path.getFirstParentPath(this, level))) {
                     Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                         putExtra(EXTRA_SHOW_ADVANCED, true)
                         putExtra(DocumentsContract.EXTRA_INITIAL_URI, createFirstParentTreeUriUsingRootTree(path))

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
@@ -13,7 +13,11 @@ import java.io.File
 
 private const val DOWNLOAD_DIR = "Download"
 private const val ANDROID_DIR = "Android"
-private val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = if(isSPlus()) listOf(DOWNLOAD_DIR, ANDROID_DIR) else listOf(DOWNLOAD_DIR)
+private val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = if (isSPlus()) {
+    listOf(DOWNLOAD_DIR, ANDROID_DIR)
+} else {
+    listOf(DOWNLOAD_DIR)
+}
 
 fun Context.hasProperStoredFirstParentUri(path: String): Boolean {
     val firstParentUri = createFirstParentTreeUri(path)
@@ -29,10 +33,10 @@ fun Context.isAccessibleWithSAFSdk30(path: String): Boolean {
     val firstParentDir =  path.getFirstParentDirName(this, level)
     val firstParentPath =  path.getFirstParentPath(this, level)
 
-    return firstParentDir != null && File(firstParentPath).isDirectory &&
-        DIRS_INACCESSIBLE_WITH_SAF_SDK_30.all {
-            !firstParentDir.equals(it, true)
-        }
+    val isValidName = firstParentDir != null
+    val isDirectory = File(firstParentPath).isDirectory
+    val isAnAccessibleDirectory = DIRS_INACCESSIBLE_WITH_SAF_SDK_30.all { !firstParentDir.equals(it, true) }
+    return isValidName && isDirectory && isAnAccessibleDirectory
 }
 
 fun Context.getFirstParentLevel(path: String): Int {
@@ -52,10 +56,10 @@ fun Context.isRestrictedWithSAFSdk30(path: String): Boolean {
     val firstParentDir =  path.getFirstParentDirName(this, level)
     val firstParentPath =  path.getFirstParentPath(this, level)
 
-    return (firstParentDir == null || (File(firstParentPath).isDirectory &&
-        DIRS_INACCESSIBLE_WITH_SAF_SDK_30.any {
-            firstParentDir.equals(it, true)
-        }))
+    val isInvalidName = firstParentDir == null
+    val isDirectory = File(firstParentPath).isDirectory
+    val isARestrictedDirectory = DIRS_INACCESSIBLE_WITH_SAF_SDK_30.any { firstParentDir.equals(it, true) }
+    return isInvalidName || (isDirectory && isARestrictedDirectory)
 }
 
 fun Context.isInDownloadDir(path: String): Boolean {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
@@ -7,11 +7,13 @@ import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
 import com.simplemobiletools.commons.helpers.EXTERNAL_STORAGE_PROVIDER_AUTHORITY
 import com.simplemobiletools.commons.helpers.isRPlus
+import com.simplemobiletools.commons.helpers.isSPlus
 import com.simplemobiletools.commons.models.FileDirItem
 import java.io.File
 
 private const val DOWNLOAD_DIR = "Download"
-val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = listOf(DOWNLOAD_DIR)
+private const val ANDROID_DIR = "Android"
+private val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = if(isSPlus()) listOf(DOWNLOAD_DIR, ANDROID_DIR) else listOf(DOWNLOAD_DIR)
 
 fun Context.hasProperStoredFirstParentUri(path: String): Boolean {
     val firstParentUri = createFirstParentTreeUri(path)
@@ -19,22 +21,71 @@ fun Context.hasProperStoredFirstParentUri(path: String): Boolean {
 }
 
 fun Context.isAccessibleWithSAFSdk30(path: String): Boolean {
-    if (path.startsWith(recycleBinPath)) {
+    if (path.startsWith(recycleBinPath) || isExternalStorageManager()) {
         return false
     }
 
-    val firstParentPath = path.getFirstParentPath(this)
-    val firstParentDir = path.getFirstParentDirName(this)
+    val level = getFirstParentLevel(path)
+    val firstParentDir =  path.getFirstParentDirName(this, level)
+    val firstParentPath =  path.getFirstParentPath(this, level)
 
-    return isRPlus() && !Environment.isExternalStorageManager() && File(firstParentPath).isDirectory &&
+    return firstParentDir != null && File(firstParentPath).isDirectory &&
         DIRS_INACCESSIBLE_WITH_SAF_SDK_30.all {
-            firstParentDir != it
+            !firstParentDir.equals(it, true)
         }
+}
+
+fun Context.getFirstParentLevel(path: String): Int {
+    return when {
+        isSPlus() && (isInAndroidDir(path) || isInDownloadDir(path)) -> 1
+        isRPlus() && isInDownloadDir(path) -> 1
+        else -> 0
+    }
+}
+
+fun Context.isRestrictedWithSAFSdk30(path: String): Boolean {
+    if (path.startsWith(recycleBinPath) || isExternalStorageManager()) {
+        return true
+    }
+
+    val level = getFirstParentLevel(path)
+    val firstParentDir =  path.getFirstParentDirName(this, level)
+    val firstParentPath =  path.getFirstParentPath(this, level)
+
+    return (firstParentDir == null || (File(firstParentPath).isDirectory &&
+        DIRS_INACCESSIBLE_WITH_SAF_SDK_30.any {
+            firstParentDir.equals(it, true)
+        }))
+}
+
+fun Context.isInDownloadDir(path: String): Boolean {
+    if (path.startsWith(recycleBinPath)) {
+        return false
+    }
+    val firstParentDir = path.getFirstParentDirName(this, 0)
+    return firstParentDir.equals(DOWNLOAD_DIR, true)
+}
+
+fun Context.isInAndroidDir(path: String): Boolean {
+    if (path.startsWith(recycleBinPath)) {
+        return false
+    }
+    val firstParentDir = path.getFirstParentDirName(this, 0)
+    return firstParentDir.equals(ANDROID_DIR, true)
+}
+
+fun isNotExternalStorageManager(): Boolean {
+    return isRPlus() && !Environment.isExternalStorageManager()
+}
+
+fun isExternalStorageManager(): Boolean {
+    return isRPlus() && Environment.isExternalStorageManager()
 }
 
 fun Context.createFirstParentTreeUriUsingRootTree(fullPath: String): Uri {
     val storageId = getSAFStorageId(fullPath)
-    val rootParentDirName = fullPath.getFirstParentDirName(this)
+    val level = getFirstParentLevel(fullPath)
+    val rootParentDirName = fullPath.getFirstParentDirName(this, level)
     val treeUri = DocumentsContract.buildTreeDocumentUri(EXTERNAL_STORAGE_PROVIDER_AUTHORITY, "$storageId:")
     val documentId = "${storageId}:$rootParentDirName"
     return DocumentsContract.buildDocumentUriUsingTree(treeUri, documentId)
@@ -42,7 +93,8 @@ fun Context.createFirstParentTreeUriUsingRootTree(fullPath: String): Uri {
 
 fun Context.createFirstParentTreeUri(fullPath: String): Uri {
     val storageId = getSAFStorageId(fullPath)
-    val rootParentDirName = fullPath.getFirstParentDirName(this)
+    val level = getFirstParentLevel(fullPath)
+    val rootParentDirName = fullPath.getFirstParentDirName(this, level)
     val firstParentId = "$storageId:$rootParentDirName"
     return DocumentsContract.buildTreeDocumentUri(EXTERNAL_STORAGE_PROVIDER_AUTHORITY, firstParentId)
 }
@@ -114,7 +166,8 @@ fun Context.getFastDocumentSdk30(path: String): DocumentFile? {
 }
 
 fun Context.getDocumentSdk30(path: String): DocumentFile? {
-    val firstParentPath = path.getFirstParentPath(this)
+    val level = getFirstParentLevel(path)
+    val firstParentPath = path.getFirstParentPath(this, level)
     var relativePath = path.substring(firstParentPath.length)
     if (relativePath.startsWith(File.separator)) {
         relativePath = relativePath.substring(1)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -41,23 +41,25 @@ fun String.isBasePath(context: Context): Boolean {
     return getBasePath(context) == this
 }
 
-fun String.getFirstParentDirName(context: Context): String? {
+fun String.getFirstParentDirName(context: Context, level: Int): String? {
     val basePath = getBasePath(context)
     val startIndex = basePath.length + 1
     return if (length > startIndex) {
         val pathWithoutBasePath = substring(startIndex)
-        pathWithoutBasePath.substringBefore("/")
+        val pathSegments = pathWithoutBasePath.split("/")
+        if (level < pathSegments.size) pathSegments.slice(0..level).joinToString("/") else null
     } else {
         null
     }
 }
 
-fun String.getFirstParentPath(context: Context): String {
+fun String.getFirstParentPath(context: Context, level: Int): String {
     val basePath = getBasePath(context)
     val startIndex = basePath.length + 1
     return if (length > startIndex) {
         val pathWithoutBasePath = substring(basePath.length + 1)
-        val firstParentPath = pathWithoutBasePath.substringBefore("/")
+        val pathSegments = pathWithoutBasePath.split("/")
+        val firstParentPath = if (level < pathSegments.size) pathSegments.slice(0..level).joinToString("/") else pathWithoutBasePath
         "$basePath/$firstParentPath"
     } else {
         basePath

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -47,7 +47,11 @@ fun String.getFirstParentDirName(context: Context, level: Int): String? {
     return if (length > startIndex) {
         val pathWithoutBasePath = substring(startIndex)
         val pathSegments = pathWithoutBasePath.split("/")
-        if (level < pathSegments.size) pathSegments.slice(0..level).joinToString("/") else null
+        if (level < pathSegments.size) {
+            pathSegments.slice(0..level).joinToString("/")
+        } else {
+            null
+        }
     } else {
         null
     }
@@ -59,7 +63,11 @@ fun String.getFirstParentPath(context: Context, level: Int): String {
     return if (length > startIndex) {
         val pathWithoutBasePath = substring(basePath.length + 1)
         val pathSegments = pathWithoutBasePath.split("/")
-        val firstParentPath = if (level < pathSegments.size) pathSegments.slice(0..level).joinToString("/") else pathWithoutBasePath
+        val firstParentPath = if (level < pathSegments.size) {
+            pathSegments.slice(0..level).joinToString("/")
+        } else {
+            pathWithoutBasePath
+        }
         "$basePath/$firstParentPath"
     } else {
         basePath


### PR DESCRIPTION
### TL/DR
users can now select subdirectories of `Android` and `Download` directory in Internal and SD Card with SAF on SDK 30+
### Notes
- handle SAF on SDK for SDK 30 and 31 for `Download` and `Android` dir
- it selects the next parent file instead of the first. For example. If a file resides in `Android/media`, they are given the option to select `Android/media` tree URI with SAF.

https://user-images.githubusercontent.com/25648077/161464860-21eea2bd-5d36-4586-b323-959fba047b02.mp4


