### PR TITLE
sdk 30 changes for gallery

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FilePickerDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/FilePickerDialog.kt
@@ -216,6 +216,15 @@ class FilePickerDialog(
                     }
                 }
             }
+        } else if (activity.isRestrictedWithSAFSdk30(currPath)) {
+            if (activity.isInDownloadDir(currPath)) {
+                val file = File(currPath)
+                if ((pickFile && file.isFile) || (!pickFile && file.isDirectory)) {
+                    sendSuccess()
+                }
+            } else {
+                activity.toast(R.string.system_folder_restriction)
+            }
         } else {
             val file = File(currPath)
             if ((pickFile && file.isFile) || (!pickFile && file.isDirectory)) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -325,18 +325,25 @@ fun Context.getMimeTypeFromUri(uri: Uri): String {
 }
 
 fun Context.ensurePublicUri(path: String, applicationId: String): Uri? {
-    return if (isRestrictedSAFOnlyRoot(path)) {
-        getAndroidSAFUri(path)
-    } else if (isPathOnOTG(path)) {
-        getDocumentFile(path)?.uri
-    } else {
-        val uri = Uri.parse(path)
-        if (uri.scheme == "content") {
-            uri
-        } else {
-            val newPath = if (uri.toString().startsWith("/")) uri.toString() else uri.path
-            val file = File(newPath)
-            getFilePublicUri(file, applicationId)
+    return when {
+        hasProperStoredAndroidTreeUri(path) && isRestrictedSAFOnlyRoot(path) -> {
+            getAndroidSAFUri(path)
+        }
+        hasProperStoredDocumentUriSdk30(path) && isAccessibleWithSAFSdk30(path) -> {
+            createDocumentUriUsingFirstParentTreeUri(path)
+        }
+        isPathOnOTG(path) -> {
+            getDocumentFile(path)?.uri
+        }
+        else -> {
+            val uri = Uri.parse(path)
+            if (uri.scheme == "content") {
+                uri
+            } else {
+                val newPath = if (uri.toString().startsWith("/")) uri.toString() else uri.path
+                val file = File(newPath)
+                getFilePublicUri(file, applicationId)
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes
- in `FilePickerDialog`, handle when a file is picked from a directory restricted on SDK 30+
- `Activity.openEditorIntent` -  do not set the flags for READ and WRITE permissions if the app does not have them
- `Activity.getFileOutputStream` - add cases for creating output stream for restricted paths on SDK30+, also for `Android/[data|obb]`
- `Context.ensurePublicUri` - add cases for creation of public uri for restricted paths on SDK30+, also for `Android/[data|obb]`
- add `Context.getPicturesDirectoryPath` to get the Pictures folder path used to save media files that are edited from restricted paths on SDK30+
- add `Context.isInSubFolderInDownloadDir` - used to determine if a path is a subfolder in the `Download` directory; useful for determining whether to show the MediaStore.createWriteRequest prompt for files in the `Download` directory