### PR TITLE
fix renaming by changing case

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/CreateNewFolderDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/CreateNewFolderDialog.kt
@@ -65,7 +65,7 @@ class CreateNewFolderDialog(val activity: BaseSimpleActivity, val path: String, 
                     }
                 }
                 File(path).mkdirs() -> sendSuccess(alertDialog, path)
-                isRPlus() && path.getParentPath().isBasePath(activity) -> activity.handleSAFCreateDocumentDialogSdk30(path) {
+                isRPlus() && activity.isAStorageRootFolder(path.getParentPath()) -> activity.handleSAFCreateDocumentDialogSdk30(path) {
                     if (it) {
                         sendSuccess(alertDialog, path)
                     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -37,10 +37,6 @@ fun String.getBasePath(context: Context): String {
     }
 }
 
-fun String.isBasePath(context: Context): Boolean {
-    return getBasePath(context) == this
-}
-
 fun String.getFirstParentDirName(context: Context, level: Int): String? {
     val basePath = getBasePath(context)
     val startIndex = basePath.length + 1

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">إلحاق بـ \'_1\'</string>
     <string name="apply_to_all">تطبيق علي الكل</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">تحديد مجلد</string>
     <string name="select_file">تحديد ملف</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">\'_1\' ilə əlavə et</string>
     <string name="apply_to_all">Hamsına şamil et</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Qovluq seç</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">Apply to all</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Select a folder</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -184,6 +184,7 @@
     <string name="append">Afegeix amb «_1»</string>
     <string name="apply_to_all">Aplica-ho a tots</string>
     <string name="system_folder_restriction">El sistema no permet l\'operació en aquesta carpeta, trieu-ne una altra</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Selecciona una carpeta</string>
     <string name="select_file">Seleccioneu un fitxer</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -188,6 +188,7 @@
     <string name="append">Ponechat s \'_1\'</string>
     <string name="apply_to_all">Použít pro všechny</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Zvolte složku</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -188,6 +188,7 @@
     <string name="append">Ychwanegu \'_1\' i\'r diwedd</string>
     <string name="apply_to_all">Gweithredu ar y cwbl</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Dewisa ffolder</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Tilføj \"_1\"</string>
     <string name="apply_to_all">Anvend på alle konflikter</string>
     <string name="system_folder_restriction">Systemet tillader ikke operationen i denne mappe, vælg en anden</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Vælg en mappe</string>
     <string name="select_file">Vælg en fil</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">\"_1\" anhängen</string>
     <string name="apply_to_all">Bei allen Konflikten anwenden</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Ordner auswählen</string>
     <string name="select_file">Datei auswählen</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -186,6 +186,7 @@
     <string name="append">Προσάρτηση με \'_1\'</string>
     <string name="apply_to_all">Εφαρμογή σε όλα</string>
     <string name="system_folder_restriction">Το Σύστημα δεν επιτρέπει τη λειτουργία σε αυτόν το φάκελο, παρακαλούμε επιλέξτε έναν άλλο φάκελο</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Επιλογή φακέλου</string>

--- a/commons/src/main/res/values-eo/strings.xml
+++ b/commons/src/main/res/values-eo/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">Apply to all</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Select a folder</string>
     <string name="select_file">Select a file</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -188,6 +188,7 @@
     <string name="append">Añadir \'_1\'</string>
     <string name="apply_to_all">Aplicar a todo</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Seleccione una carpeta</string>

--- a/commons/src/main/res/values-et/strings.xml
+++ b/commons/src/main/res/values-et/strings.xml
@@ -184,6 +184,7 @@
     <string name="append">Lisa nimele _1</string>
     <string name="apply_to_all">Kohalda kõigile</string>
     <string name="system_folder_restriction">Selles kaustas pole toimingud lubatud, palun vali mõni muu kaust</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Vali kaust</string>
     <string name="select_file">Vali fail</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -187,6 +187,7 @@
     <string name="append">Erantsi honekin: \'_1\'</string>
     <string name="apply_to_all">Aplikatu guztiei</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Hautatu karpeta</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">افزودن \'_1\' به انتها</string>
     <string name="apply_to_all">اعمال به همه</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">گزینش یک پوشه</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Lisää nimeen \'_1\'</string>
     <string name="apply_to_all">Käytä kaikkiin</string>
     <string name="system_folder_restriction">Järjestelmä ei salli toimintoa tässä kansiossa, ole hyvä ja valitse toinen</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Valitse kansio</string>
     <string name="select_file">Valitse tiedosto</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Ajouter un suffixe \"_1\"</string>
     <string name="apply_to_all">Appliquer à tous</string>
     <string name="system_folder_restriction">Le système n\'autorise pas l\'opération dans ce dossier, veuillez en choisir un autre</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Sélectionner un dossier</string>
     <string name="select_file">Sélectionner un fichier</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Engadir \'_1\'</string>
     <string name="apply_to_all">Aplicar a todo</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Selecciona un cartafol</string>
     <string name="select_file">Selecciona un ficheiro</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -186,6 +186,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">Apply to all</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Select a folder</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -186,6 +186,7 @@
     <string name="append">Dodaj s \'_1\'</string>
     <string name="apply_to_all">Primjeni na sve sukobe</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Odaberite mapu</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -184,6 +184,7 @@
     <string name="append">„_1” hozzáfűzése</string>
     <string name="apply_to_all">Alkalmaz az összesre</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Válasszon egy mappát</string>
     <string name="select_file">Válasszon egy fájlt</string>

--- a/commons/src/main/res/values-id/strings.xml
+++ b/commons/src/main/res/values-id/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Akhiri dengan \'_1\'</string>
     <string name="apply_to_all">Terapkan ke semua</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Pilih folder</string>
     <string name="select_file">Pilih berkas</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Aggiungi \'_1\' alla fine</string>
     <string name="apply_to_all">Applica a tutti i conflitti</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Seleziona una cartella</string>
     <string name="select_file">Seleziona un file</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">החל על הכל</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">בחר/י תיקייה</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">\'_1\' に追記する</string>
     <string name="apply_to_all">すべてに適用</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">フォルダを選択</string>
     <string name="select_file">ファイルを選択</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -188,6 +188,7 @@
     <string name="append">\'_1\' 문자열을 추가하기</string>
     <string name="apply_to_all">모든 충돌에 적용</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">폴더 선택</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -184,6 +184,7 @@
     <string name="append">Pridėti prie pavadinimo „_1“</string>
     <string name="apply_to_all">Taikyti visiems</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Pasirinkite aplanką</string>
     <string name="select_file">Pasirinkite failą</string>

--- a/commons/src/main/res/values-nb-rNO/strings.xml
+++ b/commons/src/main/res/values-nb-rNO/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Tilføy \'_1\'</string>
     <string name="apply_to_all">Bruk på alle konflikter</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Velg en mappe</string>
     <string name="select_file">Velg en fil</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Toevoegen met \'_1\'</string>
     <string name="apply_to_all">Toepassen op alle</string>
     <string name="system_folder_restriction">Het systeem staat de bewerking in deze map niet toe, kies een andere map</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Kies een map</string>
     <string name="select_file">Kies een bestand</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Dodaj końcówkę „_1”</string>
     <string name="apply_to_all">Zastosuj do wszystkich</string>
     <string name="system_folder_restriction">System nie pozwala na operację w tym folderze, wybierz inny</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Wybierz folder</string>
     <string name="select_file">Wybierz plik</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Adicionar sufixo \'_1\'</string>
     <string name="apply_to_all">Aplicar a todos os conflitos</string>
     <string name="system_folder_restriction">O sistema não permite a operação nesta pasta, por favor escolha outra</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Selecionar pasta</string>
     <string name="select_file">Selecionar arquivo</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Anexar \'_1\'</string>
     <string name="apply_to_all">Aplicar a todos</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Selecionar pasta</string>
     <string name="select_file">Selecionar ficheiro</string>

--- a/commons/src/main/res/values-ro/strings.xml
+++ b/commons/src/main/res/values-ro/strings.xml
@@ -179,6 +179,7 @@
     <string name="append">Adăugaţi cu \'_1\'</string>
     <string name="apply_to_all">Se aplică tuturor</string>
     <string name="system_folder_restriction">Sistemul nu permite operarea în acest dosar, vă rugăm să alegeți un alt dosar</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Selectaţi un dosar</string>
     <string name="select_file">Selectaţi un dosar</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -184,6 +184,7 @@
     <string name="append">Добавить \"_1\" к имени</string>
     <string name="apply_to_all">Применить ко всем</string>
     <string name="system_folder_restriction">Система не разрешает операции в этой папке, выберите другую</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Выбор папки</string>
     <string name="select_file">Выбор файла</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -189,7 +189,7 @@
     <string name="append">Pripnúť \'_1\'</string>
     <string name="apply_to_all">Použiť na všetky konflikty</string>
     <string name="system_folder_restriction">Systém nepovoľuje túto operáciu v tomto priečinku, prosím zvoľte iný</string>
-    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
+    <string name="rename_in_sd_card_system_restriction">Systém v tomto priečinku nepovoľuje premenovávanie</string>
 
     <!-- File picker -->
     <string name="select_folder">Zvoľte priečinok</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Pripnúť \'_1\'</string>
     <string name="apply_to_all">Použiť na všetky konflikty</string>
     <string name="system_folder_restriction">Systém nepovoľuje túto operáciu v tomto priečinku, prosím zvoľte iný</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Zvoľte priečinok</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Dodaj \'_1\'</string>
     <string name="apply_to_all">Uporabi za vse</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Izberi mapo</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Додај суфикс \'_1\'</string>
     <string name="apply_to_all">Примени на све</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Изабери фасциклу</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Lägg till \'_1\'</string>
     <string name="apply_to_all">Använd på alla konflikter</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Välj mapp</string>
     <string name="select_file">Välj fil</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">Apply to all</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">கோப்புறையை தேர்ந்தெடு</string>
     <string name="select_file">கோப்பை தேர்ந்தெடு</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">\'_1\' ile ekle</string>
     <string name="apply_to_all">Tümüne uygula</string>
     <string name="system_folder_restriction">Sistem bu klasörde işlem yapmaya izin vermiyor, lütfen başka bir tane seçin</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Bir klasör seç</string>
     <string name="select_file">Bir dosya seç</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">Додати \'_1\' в кінець</string>
     <string name="apply_to_all">Застосувати до усіх</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">Обрати теку</string>
     <string name="select_file">Обрати файл</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Nối với \'_1\'</string>
     <string name="apply_to_all">Áp dụng cho tất cả</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Chọn một thư mục</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">应用到 \'_1\'</string>
     <string name="apply_to_all">应用到全部冲突项</string>
     <string name="system_folder_restriction">系统不允许在此文件夹中操作，请选择另一个文件夹</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">选择文件夹</string>
     <string name="select_file">选择文件</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -178,6 +178,7 @@
     <string name="append">附加 \'_1\'</string>
     <string name="apply_to_all">添加到全部衝突</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
     <!-- File picker -->
     <string name="select_folder">選擇資料夾</string>
     <string name="select_file">選擇檔案</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -189,6 +189,7 @@
     <string name="append">Append with \'_1\'</string>
     <string name="apply_to_all">Apply to all</string>
     <string name="system_folder_restriction">The system does not allow the operation in this folder, please pick another one</string>
+    <string name="rename_in_sd_card_system_restriction">The system does not allow renaming in this folder</string>
 
     <!-- File picker -->
     <string name="select_folder">Select a folder</string>


### PR DESCRIPTION
### Changes
- in `Activity.renameFile`, handle the case for just casing change in the new file name
- add new string rename_in_sd_card_system_restriction shown as an error when renaming files on the root of the SD Card when the app is not the external storage manager on SDK 30+

### Cleanup
- remove `String.isBasePath` method that does the same thing as the `Context.isAStorageRootFolder`