### PR TITLE
add the ACCESS_MEDIA_LOCATION permission

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -224,6 +224,7 @@ fun Context.getPermissionString(id: Int) = when (id) {
     PERMISSION_READ_SMS -> Manifest.permission.READ_SMS
     PERMISSION_SEND_SMS -> Manifest.permission.SEND_SMS
     PERMISSION_READ_PHONE_STATE -> Manifest.permission.READ_PHONE_STATE
+    PERMISSION_MEDIA_LOCATION -> if (isQPlus()) Manifest.permission.ACCESS_MEDIA_LOCATION else ""
     else -> ""
 }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -262,6 +262,7 @@ const val PERMISSION_GET_ACCOUNTS = 12
 const val PERMISSION_READ_SMS = 13
 const val PERMISSION_SEND_SMS = 14
 const val PERMISSION_READ_PHONE_STATE = 15
+const val PERMISSION_MEDIA_LOCATION = 16
 
 // conflict resolving
 const val CONFLICT_SKIP = 1


### PR DESCRIPTION
### Notes
- add the `ACCESS_MEDIA_LOCATION` permission
- the `ACCESS_MEDIA_LOCATION` is available from Android 10 (Q) and above