### PR TITLE
add the Android folder to restricted folders on SDK30+

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
@@ -7,17 +7,12 @@ import android.provider.DocumentsContract
 import androidx.documentfile.provider.DocumentFile
 import com.simplemobiletools.commons.helpers.EXTERNAL_STORAGE_PROVIDER_AUTHORITY
 import com.simplemobiletools.commons.helpers.isRPlus
-import com.simplemobiletools.commons.helpers.isSPlus
 import com.simplemobiletools.commons.models.FileDirItem
 import java.io.File
 
 private const val DOWNLOAD_DIR = "Download"
 private const val ANDROID_DIR = "Android"
-private val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = if (isSPlus()) {
-    listOf(DOWNLOAD_DIR, ANDROID_DIR)
-} else {
-    listOf(DOWNLOAD_DIR)
-}
+private val DIRS_INACCESSIBLE_WITH_SAF_SDK_30 = listOf(DOWNLOAD_DIR, ANDROID_DIR)
 
 fun Context.hasProperStoredFirstParentUri(path: String): Boolean {
     val firstParentUri = createFirstParentTreeUri(path)
@@ -41,8 +36,7 @@ fun Context.isAccessibleWithSAFSdk30(path: String): Boolean {
 
 fun Context.getFirstParentLevel(path: String): Int {
     return when {
-        isSPlus() && (isInAndroidDir(path) || isInSubFolderInDownloadDir(path)) -> 1
-        isRPlus() && isInSubFolderInDownloadDir(path) -> 1
+        isRPlus() && (isInAndroidDir(path) || isInSubFolderInDownloadDir(path)) -> 1
         else -> 0
     }
 }


### PR DESCRIPTION
### Notes
- one cannot select the root of the `Android` folder with SAF on some Android 11 devices (eg. Samsung)
- this fix adds the `Android` folder to the list of restricted directories on SDK 30+

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/163668601-0c8bd974-56dc-465c-bb66-7554b23d2cc7.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/163668607-a2953b88-2fbe-49a8-a4ef-e9a7025155c6.mp4" width="320"/>






