### PR TITLE
handle manage media permission

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -56,12 +56,14 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
     private val DELETE_FILE_SDK_30_HANDLER = 300
     private val RECOVERABLE_SECURITY_HANDLER = 301
     private val UPDATE_FILE_SDK_30_HANDLER = 302
+    private val MANAGE_MEDIA_RC = 303
 
     companion object {
         var funAfterSAFPermission: ((success: Boolean) -> Unit)? = null
         var funAfterSdk30Action: ((success: Boolean) -> Unit)? = null
         var funAfterUpdate30File: ((success: Boolean) -> Unit)? = null
         var funRecoverableSecurity: ((success: Boolean) -> Unit)? = null
+        var funAfterManageMediaPermission: (() -> Unit)? = null
     }
 
     abstract fun getAppIconIDs(): ArrayList<Int>
@@ -393,6 +395,8 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             funRecoverableSecurity = null
         } else if (requestCode == UPDATE_FILE_SDK_30_HANDLER) {
             funAfterUpdate30File?.invoke(resultCode == Activity.RESULT_OK)
+        } else if (requestCode == MANAGE_MEDIA_RC) {
+            funAfterManageMediaPermission?.invoke()
         }
     }
 
@@ -605,6 +609,15 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             } else {
                 callback(false)
             }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    fun launchMediaManagementIntent(callback: () -> Unit) {
+        Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
+            data = Uri.parse("package:$packageName")
+            startActivityForResult(this, MANAGE_MEDIA_RC)
+            funAfterManageMediaPermission = callback
         }
     }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -617,8 +617,8 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
         Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
             data = Uri.parse("package:$packageName")
             startActivityForResult(this, MANAGE_MEDIA_RC)
-            funAfterManageMediaPermission = callback
         }
+        funAfterManageMediaPermission = callback
     }
 
     fun copyMoveFilesTo(

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -975,7 +975,7 @@ private fun BaseSimpleActivity.renameCasually(
     val tempFile = try {
         createTempFile(oldFile) ?: return
     } catch (exception: Exception) {
-        if (isRPlus() && exception is java.nio.file.FileSystemException) {
+        if (isRPlus() && exception is FileSystemException) {
             // if we are renaming multiple files at once, we should give the Android 30+ permission dialog all uris together, not one by one
             if (isRenamingMultipleFiles) {
                 callback?.invoke(false, Android30RenameFormat.CONTENT_RESOLVER)


### PR DESCRIPTION
## Notes
- handle manage media permission for renaming
- add `BaseSimpleActivity.launchMediaManagementIntent`
    - we need this so we can detect when a user has activated or denied the permission to trigger a callback