### PR TITLE
Feat/manage media

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -508,6 +508,16 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
         }
     }
 
+    fun checkManageMediaOrHandleSAFDialogSdk30(path: String, callback: (success: Boolean) -> Unit): Boolean {
+        hideKeyboard()
+        return if (canManageMedia()) {
+            callback(true)
+            false
+        } else {
+            handleSAFDialogSdk30(path, callback)
+        }
+    }
+
     fun handleSAFCreateDocumentDialogSdk30(path: String, callback: (success: Boolean) -> Unit): Boolean {
         hideKeyboard()
         return if (!packageName.startsWith("com.simplemobiletools")) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -720,9 +720,9 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
             return@handleSAFDialog
         }
 
-        handleSAFDialogSdk30(firstFile.path) {
+        checkManageMediaOrHandleSAFDialogSdk30(firstFile.path) {
             if (!it) {
-                return@handleSAFDialogSdk30
+                return@checkManageMediaOrHandleSAFDialogSdk30
             }
 
             val failedFileDirItems = ArrayList<FileDirItem>()
@@ -809,22 +809,30 @@ fun BaseSimpleActivity.deleteFileBg(
                         }
                     }
                 } else if (isAccessibleWithSAFSdk30(path)) {
-                    handleSAFDialogSdk30(path) {
-                        if (it) {
-                            deleteDocumentWithSAFSdk30(fileDirItem, allowDeleteFolder, callback)
+                    if (canManageMedia()) {
+                        deleteSdk30(fileDirItem, callback)
+                    } else {
+                        handleSAFDialogSdk30(path) {
+                            if (it) {
+                                deleteDocumentWithSAFSdk30(fileDirItem, allowDeleteFolder, callback)
+                            }
                         }
                     }
                 } else if (isRPlus() && !isDeletingMultipleFiles) {
-                    val fileUris = getFileUrisFromFileDirItems(arrayListOf(fileDirItem)).second
-                    deleteSDK30Uris(fileUris) { success ->
-                        runOnUiThread {
-                            callback?.invoke(success)
-                        }
-                    }
+                    deleteSdk30(fileDirItem, callback)
                 } else {
                     callback?.invoke(false)
                 }
             }
+        }
+    }
+}
+
+private fun BaseSimpleActivity.deleteSdk30(fileDirItem: FileDirItem, callback: ((wasSuccess: Boolean) -> Unit)?) {
+    val fileUris = getFileUrisFromFileDirItems(arrayListOf(fileDirItem)).second
+    deleteSDK30Uris(fileUris) { success ->
+        runOnUiThread {
+            callback?.invoke(success)
         }
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -983,7 +983,7 @@ private fun BaseSimpleActivity.renameCasually(
     val tempFile = try {
         createTempFile(oldFile) ?: return
     } catch (exception: Exception) {
-        if (isRPlus() && exception is FileSystemException) {
+        if (isRPlus() && exception is java.nio.file.FileSystemException) {
             // if we are renaming multiple files at once, we should give the Android 30+ permission dialog all uris together, not one by one
             if (isRenamingMultipleFiles) {
                 callback?.invoke(false, Android30RenameFormat.CONTENT_RESOLVER)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
@@ -58,80 +58,67 @@ class RenameSimpleTab(context: Context, attrs: AttributeSet) : RelativeLayout(co
                 return@handleSAFDialog
             }
 
-            if (activity?.canManageMedia() == true) {
-                renameFiles(validPaths, append, valueToAdd, callback)
-            } else {
-                activity?.handleSAFDialogSdk30(firstPath) { granted ->
-                    if (!granted) {
-                        return@handleSAFDialogSdk30
-                    }
-
-                    renameFiles(validPaths, append, valueToAdd, callback)
+            activity?.checkManageMediaOrHandleSAFDialogSdk30(firstPath) {
+                if (!it) {
+                    return@checkManageMediaOrHandleSAFDialogSdk30
                 }
-            }
-        }
-    }
 
-    private fun renameFiles(
-        validPaths: List<String>,
-        append: Boolean,
-        valueToAdd: String,
-        callback: (success: Boolean) -> Unit
-    ) {
-        ignoreClicks = true
-        var pathsCnt = validPaths.size
-        for (path in validPaths) {
-            if (stopLooping) {
-                return
-            }
-
-            val fullName = path.getFilenameFromPath()
-            var dotAt = fullName.lastIndexOf(".")
-            if (dotAt == -1) {
-                dotAt = fullName.length
-            }
-
-            val name = fullName.substring(0, dotAt)
-            val extension = if (fullName.contains(".")) ".${fullName.getFilenameExtension()}" else ""
-
-            val newName = if (append) {
-                "$name$valueToAdd$extension"
-            } else {
-                "$valueToAdd$fullName"
-            }
-
-            val newPath = "${path.getParentPath()}/$newName"
-
-            if (activity?.getDoesFilePathExist(newPath) == true) {
-                continue
-            }
-
-            activity?.renameFile(path, newPath, true) { success, android30Format ->
-                if (success) {
-                    pathsCnt--
-                    if (pathsCnt == 0) {
-                        callback(true)
+                ignoreClicks = true
+                var pathsCnt = validPaths.size
+                for (path in validPaths) {
+                    if (stopLooping) {
+                        return@checkManageMediaOrHandleSAFDialogSdk30
                     }
-                } else {
-                    ignoreClicks = false
-                    if (android30Format != Android30RenameFormat.NONE) {
-                        stopLooping = true
-                        renameAllFilesSdk30(validPaths, append, valueToAdd, android30Format, callback)
+
+                    val fullName = path.getFilenameFromPath()
+                    var dotAt = fullName.lastIndexOf(".")
+                    if (dotAt == -1) {
+                        dotAt = fullName.length
+                    }
+
+                    val name = fullName.substring(0, dotAt)
+                    val extension = if (fullName.contains(".")) ".${fullName.getFilenameExtension()}" else ""
+
+                    val newName = if (append) {
+                        "$name$valueToAdd$extension"
                     } else {
-                        activity?.toast(R.string.unknown_error_occurred)
+                        "$valueToAdd$fullName"
+                    }
+
+                    val newPath = "${path.getParentPath()}/$newName"
+
+                    if (activity?.getDoesFilePathExist(newPath) == true) {
+                        continue
+                    }
+
+                    activity?.renameFile(path, newPath, true) { success, android30Format ->
+                        if (success) {
+                            pathsCnt--
+                            if (pathsCnt == 0) {
+                                callback(true)
+                            }
+                        } else {
+                            ignoreClicks = false
+                            if (android30Format != Android30RenameFormat.NONE) {
+                                stopLooping = true
+                                renameAllFiles(validPaths, append, valueToAdd, android30Format, callback)
+                            } else {
+                                activity?.toast(R.string.unknown_error_occurred)
+                            }
+                        }
                     }
                 }
+                stopLooping = false
             }
         }
-        stopLooping = false
     }
 
-    private fun renameAllFilesSdk30(
+    private fun renameAllFiles(
         paths: List<String>,
         appendString: Boolean,
         stringToAdd: String,
         android30Format: Android30RenameFormat,
-        callback: (success: Boolean) -> Unit,
+        callback: (success: Boolean) -> Unit
     ) {
         val fileDirItems = paths.map { File(it).toFileDirItem(context) }
         val uriPairs = context.getFileUrisFromFileDirItems(fileDirItems)


### PR DESCRIPTION
## Notes
- add `BaseSimpleActivity.checkManageMediaOrHandleSAFDialogSdk30` used in delete/rename operations
    - this checks for whether the app is should use Storage Access Framework (`SAF`) or `MediaStore` request
    - on SDK 31, if the app can manage media, the `MediaStore` request method would be used
    - on SDK 31, if the app cannot manage media, then the `SAF` method is used
    - on SDK 30, the SAF is used as the `MANAGE_MEDIA` permission was added in SDK 31
- revert changes in `RenamePatternTab` and `RenameSimpleTab` and use the `checkManageMediaOrHandleSAFDialogSdk30` method