### PR TITLE
fix renaming on Android 12

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -902,7 +902,7 @@ fun BaseSimpleActivity.renameFile(
             }
         }
     } else if (isAccessibleWithSAFSdk30(oldPath)) {
-        if (canManageMedia()) {
+        if (canManageMedia() && isPathOnInternalStorage(oldPath)) {
             renameCasually(oldPath, newPath, isRenamingMultipleFiles, callback)
         } else {
             handleSAFDialogSdk30(oldPath) {


### PR DESCRIPTION
## Notes
- only rename with MediaStore when the app can manage media if the path is on internal storage, otherwise, use Storage Access Framework
- if the path is on SD Card, we get an exception