### PR TITLE
fix unable to delete files in recycle bin when app can manage media

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -111,7 +111,7 @@ fun Activity.appLaunched(appId: String) {
     }
 
     if (baseConfig.appRunCount % 40 == 0 && !baseConfig.wasAppRated) {
-        if (!resources.getBoolean(R.bool.hide_google_relations)) {
+        if (!resources.getBoolean(R.bool.hide_google_relations) && !resources.getBoolean(R.bool.avoid_showing_rating_prompt)) {
             RateStarsDialog(this)
         }
     }
@@ -726,7 +726,7 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
 
             if (canManageMedia()) {
                 val fileUris = getFileUrisFromFileDirItems(files).second
-                if(fileUris.size == files.size){
+                if (fileUris.size == files.size) {
                     deleteSDK30Uris(fileUris) { success ->
                         runOnUiThread {
                             callback?.invoke(success)
@@ -742,7 +742,11 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
     }
 }
 
-private fun BaseSimpleActivity.deleteFilesCasual(files: List<FileDirItem>, allowDeleteFolder: Boolean = false, callback: ((wasSuccess: Boolean) -> Unit)? = null){
+private fun BaseSimpleActivity.deleteFilesCasual(
+    files: List<FileDirItem>,
+    allowDeleteFolder: Boolean = false,
+    callback: ((wasSuccess: Boolean) -> Unit)? = null
+) {
     var wasSuccess = false
     val failedFileDirItems = ArrayList<FileDirItem>()
     files.forEachIndexed { index, file ->


### PR DESCRIPTION
## Notes
- only proceed to delete files with `MediaStore.createDeleteRequest`
if the conversion of the FileDirItems to URI works for all the files in the list
delete casually otherwise, which would loop through all files one by one