### PR TITLE
fix: moving when app can manage media

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -660,16 +660,34 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                 copyMoveCallback = callback
                 var fileCountToCopy = fileDirItems.size
                 if (isCopyOperation) {
-                    startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                    if(canManageMedia()){
+                        val fileUris = getFileUrisFromFileDirItems(fileDirItems).second
+                        updateSDK30Uris(fileUris) { sdk30UriSuccess ->
+                            if (sdk30UriSuccess) {
+                                startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                            }
+                        }
+                    } else {
+                        startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                    }
                 } else {
                     if (isPathOnOTG(source) || isPathOnOTG(destination) || isPathOnSD(source) || isPathOnSD(destination) ||
                         isRestrictedSAFOnlyRoot(source) || isRestrictedSAFOnlyRoot(destination) ||
                         isAccessibleWithSAFSdk30(source) || isAccessibleWithSAFSdk30(destination) ||
                         fileDirItems.first().isDirectory
                     ) {
-                        handleSAFDialog(source) {
-                            if (it) {
-                                startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                        handleSAFDialog(source) { safSuccess ->
+                            if (safSuccess) {
+                                if(canManageMedia()){
+                                    val fileUris = getFileUrisFromFileDirItems(fileDirItems).second
+                                    updateSDK30Uris(fileUris) { sdk30UriSuccess ->
+                                        if (sdk30UriSuccess) {
+                                            startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                                        }
+                                    }
+                                } else {
+                                    startCopyMove(fileDirItems, destination, isCopyOperation, copyPhotoVideoOnly, copyHidden)
+                                }
                             }
                         }
                     } else {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/asynctasks/CopyMoveTask.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/asynctasks/CopyMoveTask.kt
@@ -12,10 +12,7 @@ import androidx.documentfile.provider.DocumentFile
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.extensions.*
-import com.simplemobiletools.commons.helpers.CONFLICT_KEEP_BOTH
-import com.simplemobiletools.commons.helpers.CONFLICT_SKIP
-import com.simplemobiletools.commons.helpers.getConflictResolution
-import com.simplemobiletools.commons.helpers.isOreoPlus
+import com.simplemobiletools.commons.helpers.*
 import com.simplemobiletools.commons.interfaces.CopyMoveListener
 import com.simplemobiletools.commons.models.FileDirItem
 import java.io.File
@@ -277,33 +274,16 @@ class CopyMoveTask(
                 if (copyOnly) {
                     activity.rescanPath(destination.path) {
                         if (activity.baseConfig.keepLastModified) {
-                            if (activity.canManageMedia()) {
-                                val fileUris = activity.getFileUrisFromFileDirItems(arrayListOf(destination)).second
-                                activity.updateSDK30Uris(fileUris) {
-                                    updateLastModifiedValues(source, destination)
-                                    activity.rescanPath(destination.path)
-                                }
-                            } else {
-                                updateLastModifiedValues(source, destination)
-                            }
+                            updateLastModifiedValues(source, destination)
+                            activity.rescanPath(destination.path)
                         }
                     }
                 } else if (activity.baseConfig.keepLastModified) {
-                    if (activity.canManageMedia()) {
-                        val fileUris = activity.getFileUrisFromFileDirItems(arrayListOf(destination)).second
-                        activity.updateSDK30Uris(fileUris) {
-                            updateLastModifiedValues(source, destination)
-                            activity.rescanPath(destination.path)
-                            inputStream.close()
-                            out?.close()
-                            deleteSourceFile(source)
-                        }
-                    } else {
-                        updateLastModifiedValues(source, destination)
-                        inputStream.close()
-                        out?.close()
-                        deleteSourceFile(source)
-                    }
+                    updateLastModifiedValues(source, destination)
+                    activity.rescanPath(destination.path)
+                    inputStream.close()
+                    out?.close()
+                    deleteSourceFile(source)
                 } else {
                     inputStream.close()
                     out?.close()


### PR DESCRIPTION
## Notes
- avoid calling `activity.updateSDK30Uris` in each iteration for copy/move
- especially when moving, since `deleteSourceFile` is called in the callback of `activity.updateSDK30Uris`,
- in most cases, the async task would have called the code in  `onPostExecute` and the UI would have tried to reload before the deletion completes
- we move the call to `activity.updateSDK30Uris` in `BaseSimpleActivity.copyMoveFilesTo`, so it happens early enough and is batched for all the files instead of per iteration
- related to [this Simple-Gallery PR](https://github.com/SimpleMobileTools/Simple-Gallery/pull/2483)
- closes [this issue](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2470)

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/170144817-b10d90fa-e5c9-4ae6-bfd5-41fae91eed8d.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/170145277-03a4e6e3-e272-4865-84e6-67b3b90fae48.mov" width="320"/>












