### PR TITLE
fix: error when copying from recycle bin on SDK 31+

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -660,7 +660,8 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                 copyMoveCallback = callback
                 var fileCountToCopy = fileDirItems.size
                 if (isCopyOperation) {
-                    if (canManageMedia()) {
+                    val recycleBinPath = fileDirItems.first().isRecycleBinPath(this)
+                    if (canManageMedia() && !recycleBinPath) {
                         val fileUris = getFileUrisFromFileDirItems(fileDirItems).second
                         updateSDK30Uris(fileUris) { sdk30UriSuccess ->
                             if (sdk30UriSuccess) {
@@ -678,7 +679,8 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                     ) {
                         handleSAFDialog(source) { safSuccess ->
                             if (safSuccess) {
-                                if (canManageMedia()) {
+                                val recycleBinPath = fileDirItems.first().isRecycleBinPath(this)
+                                if (canManageMedia() && !recycleBinPath) {
                                     val fileUris = getFileUrisFromFileDirItems(fileDirItems).second
                                     updateSDK30Uris(fileUris) { sdk30UriSuccess ->
                                         if (sdk30UriSuccess) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -724,16 +724,13 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
                 return@checkManageMediaOrHandleSAFDialogSdk30
             }
 
-            if (canManageMedia()) {
+            val recycleBinPath = firstFile.isRecycleBinPath(this)
+            if (canManageMedia() && !recycleBinPath) {
                 val fileUris = getFileUrisFromFileDirItems(files).second
-                if (fileUris.size == files.size) {
-                    deleteSDK30Uris(fileUris) { success ->
-                        runOnUiThread {
-                            callback?.invoke(success)
-                        }
+                deleteSDK30Uris(fileUris) { success ->
+                    runOnUiThread {
+                        callback?.invoke(success)
                     }
-                } else {
-                    deleteFilesCasual(files, allowDeleteFolder, callback)
                 }
             } else {
                 deleteFilesCasual(files, allowDeleteFolder, callback)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/FileDirItem.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/FileDirItem.kt
@@ -1,0 +1,8 @@
+package com.simplemobiletools.commons.extensions
+
+import android.content.Context
+import com.simplemobiletools.commons.models.FileDirItem
+
+fun FileDirItem.isRecycleBinPath(context: Context): Boolean {
+    return path.startsWith(context.recycleBinPath)
+}


### PR DESCRIPTION
## Notes
- fix `NoSuchElementException`, thrown when copying files from the recycle bin on Android 12+ devices.
- only convert the paths to URIs needed for MediaStore.createWriteRequest  if the path is  not a recycle bin path
- add extension function `FileDirItem.isRecycleBinPath` for checking if a FileDirItem's path starts with the `recycleBinPath` to prevent duplication

**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/171302328-1f81ea30-3b3c-4de2-b062-b7ce95fe736d.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/171302347-6477859b-7fe1-4ffc-b17b-9a8e1d7439f2.mp4" width="320"/>







