### PR TITLE
fix: writing to SD Card very slow

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -1304,8 +1304,12 @@ fun BaseSimpleActivity.getFileOutputStreamSync(path: String, mimeType: String, p
             }
 
             try {
-                val newDocument = getDocumentFile(path) ?: documentFile.createFile(mimeType, path.getFilenameFromPath())
-                applicationContext.contentResolver.openOutputStream(newDocument!!.uri)
+                val uri = if (getDoesFilePathExist(path)) {
+                    createDocumentUriFromRootTree(path)
+                } else {
+                    documentFile.createFile(mimeType, path.getFilenameFromPath())!!.uri
+                }
+                applicationContext.contentResolver.openOutputStream(uri)
             } catch (e: Exception) {
                 showErrorToast(e)
                 null


### PR DESCRIPTION
# Notes
- in an attempt to fix the overwrite issue in [this PR](https://github.com/SimpleMobileTools/Simple-Commons/pull/1351),
 the slow `getDocumentFile` was used.
 - `getDocumentFile` iterates over the list of files in the parent folder and tries to locate the file if it exists
 - for fresh copy/move, it would check the entire list of files and not find the path, this greatly slows down the speed.
 - the fix for it is that we
    -  Check if the file path exists
       - if it does, we construct the URI manually using the `createDocumentUriFromRootTree` method
       - else, we call `documentFile.createFile` and get the newly created URI

 - calling `createDocumentUriFromRootTree` is fast
 - `getDocumentFast` does not work so it was not used
 - closes the Simple-Gallery [issue 2491](https://github.com/SimpleMobileTools/Simple-Gallery/issues/2491)
 
 
 
 
 **Simple Gallery fix**
**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/172179098-518280e0-5200-4993-b8fc-eafd8f11efba.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/172179177-c4135f33-7045-46c3-81ca-f23d852bf09f.mp4" width="320"/>








