### PR TITLE
fix: moving on pre SDK 30

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context-storage-sdk30.kt
@@ -55,7 +55,7 @@ fun Context.isRestrictedWithSAFSdk30(path: String): Boolean {
     val isInvalidName = firstParentDir == null
     val isDirectory = File(firstParentPath).isDirectory
     val isARestrictedDirectory = DIRS_INACCESSIBLE_WITH_SAF_SDK_30.any { firstParentDir.equals(it, true) }
-    return isRPlus() && isInvalidName || (isDirectory && isARestrictedDirectory)
+    return isRPlus() && (isInvalidName || (isDirectory && isARestrictedDirectory))
 }
 
 fun Context.isInDownloadDir(path: String): Boolean {


### PR DESCRIPTION
# Notes
- fix the condition for isRestrictedWithSAFSdk30 that affected devices on SDK 29 and below
- verified that fix does not affect SDK30+
- the error happened because, this check on [CopyMoveTask.kt#L315](https://github.com/SimpleMobileTools/Simple-Commons/blob/master/commons/src/main/kotlin/com/simplemobiletools/commons/asynctasks/CopyMoveTask.kt#L315), went into the `if` block on SDK 29 and below. It should only apply to SDK 30+ 


**Before** | **After**
---|---
<video src="https://user-images.githubusercontent.com/25648077/174002186-5901b71c-527b-41cc-a3bc-e2f29aea0db3.mp4" width="320"/> | <video src="https://user-images.githubusercontent.com/25648077/174002215-f70993b1-4a6b-4937-8caa-3064f4ac73c6.mp4" width="320"/>








