### PR TITLE
fix: renaming folders in gallery

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -930,7 +930,7 @@ fun BaseSimpleActivity.renameFile(
             }
         }
     } else if (isAccessibleWithSAFSdk30(oldPath)) {
-        if (canManageMedia() && isPathOnInternalStorage(oldPath)) {
+        if (canManageMedia() && !File(oldPath).isDirectory && isPathOnInternalStorage(oldPath)) {
             renameCasually(oldPath, newPath, isRenamingMultipleFiles, callback)
         } else {
             handleSAFDialogSdk30(oldPath) {
@@ -952,6 +952,11 @@ fun BaseSimpleActivity.renameFile(
                     }
                 }
             }
+        }
+    } else if (isRestrictedWithSAFSdk30(oldPath)) {
+        runOnUiThread {
+            toast(R.string.rename_in_sd_card_system_restriction)
+            callback?.invoke(false, Android30RenameFormat.NONE)
         }
     } else if (needsStupidWritePermissions(newPath)) {
         handleSAFDialog(newPath) {


### PR DESCRIPTION
## Notes
- use SAF when renaming folders on SDK 30+,
- show the `rename_internal_system_restriction` error if `IOException` is thrown while renaming a restricted folder
The error applies to `Downloads` and `Android` folders on the SD card and internal storage. The message only specifies internal storage. We may want to revise the message. 

- fix weird behaviour when renaming on SDK 30+, this was because the media store was not updated after renaming
   -  to reproduce and test the fix:
        - Change the sort order to last modified
        - Try to rename a root folder




