### PR TITLE
fix: showing multiple toast error during renaming

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemDialog.kt
@@ -75,13 +75,11 @@ class RenameItemDialog(val activity: BaseSimpleActivity, val path: String, val c
 
                         updatedPaths.add(newPath)
                         ignoreClicks = true
-                        activity.renameFile(path, newPath, false) { success, useAndroid30Way ->
+                        activity.renameFile(path, newPath, false) { success, _ ->
                             ignoreClicks = false
                             if (success) {
                                 callback(newPath)
                                 dismiss()
-                            } else {
-                                activity.toast(R.string.unknown_error_occurred)
                             }
                         }
                     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemsDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/RenameItemsDialog.kt
@@ -76,7 +76,7 @@ class RenameItemsDialog(val activity: BaseSimpleActivity, val paths: ArrayList<S
                                     continue
                                 }
 
-                                activity.renameFile(path, newPath, true) { success, useAndroid30Way ->
+                                activity.renameFile(path, newPath, true) { success, _ ->
                                     if (success) {
                                         pathsCnt--
                                         if (pathsCnt == 0) {
@@ -85,7 +85,6 @@ class RenameItemsDialog(val activity: BaseSimpleActivity, val paths: ArrayList<S
                                         }
                                     } else {
                                         ignoreClicks = false
-                                        activity.toast(R.string.unknown_error_occurred)
                                         dismiss()
                                     }
                                 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -972,6 +972,7 @@ fun BaseSimpleActivity.renameFile(
             val document = getSomeDocumentFile(oldPath)
             if (document == null || (File(oldPath).isDirectory != document.isDirectory)) {
                 runOnUiThread {
+                    toast(R.string.unknown_error_occurred)
                     callback?.invoke(false, Android30RenameFormat.NONE)
                 }
                 return@handleSAFDialog
@@ -1105,6 +1106,7 @@ private fun BaseSimpleActivity.renameCasually(
                             val tempDestination = try {
                                 createTempFile(File(sourceFile.path)) ?: return@updateSDK30Uris
                             } catch (exception: Exception) {
+                                toast(R.string.unknown_error_occurred)
                                 callback?.invoke(false, Android30RenameFormat.NONE)
                                 return@updateSDK30Uris
                             }
@@ -1147,6 +1149,7 @@ private fun BaseSimpleActivity.renameCasually(
                                     }
                                 }
                             } else {
+                                toast(R.string.unknown_error_occurred)
                                 callback?.invoke(false, Android30RenameFormat.NONE)
                             }
                         }
@@ -1158,6 +1161,7 @@ private fun BaseSimpleActivity.renameCasually(
                 }
             }
         } else {
+            toast(R.string.unknown_error_occurred)
             callback?.invoke(false, Android30RenameFormat.NONE)
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -1106,7 +1106,7 @@ private fun BaseSimpleActivity.renameCasually(
                             val tempDestination = try {
                                 createTempFile(File(sourceFile.path)) ?: return@updateSDK30Uris
                             } catch (exception: Exception) {
-                                toast(R.string.unknown_error_occurred)
+                                showErrorToast(exception)
                                 callback?.invoke(false, Android30RenameFormat.NONE)
                                 return@updateSDK30Uris
                             }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
@@ -92,8 +92,6 @@ class RenamePatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(c
                                     currentIncrementalNumber = 1
                                     stopLooping = true
                                     renameAllFiles(validPaths, useMediaFileExtension, android30Format, callback)
-                                } else {
-                                    activity?.toast(R.string.unknown_error_occurred)
                                 }
                             }
                         }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
@@ -102,8 +102,6 @@ class RenameSimpleTab(context: Context, attrs: AttributeSet) : RelativeLayout(co
                             if (android30Format != Android30RenameFormat.NONE) {
                                 stopLooping = true
                                 renameAllFiles(validPaths, append, valueToAdd, android30Format, callback)
-                            } else {
-                                activity?.toast(R.string.unknown_error_occurred)
                             }
                         }
                     }


### PR DESCRIPTION
# Notes
- remove toast error for unknown error during renaming when `success=false` to avoid multiple toasts
- show the unknown error just for cases where applicable