### PR TITLE
Add helper function to block numbers matching a pattern

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/AddBlockedNumberDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/AddBlockedNumberDialog.kt
@@ -22,12 +22,16 @@ class AddBlockedNumberDialog(val activity: BaseSimpleActivity, val originalNumbe
                 activity.setupDialogStuff(view, this) { alertDialog ->
                     alertDialog.showKeyboard(view.add_blocked_number_edittext)
                     alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
-                        val newBlockedNumber = view.add_blocked_number_edittext.value
+                        var newBlockedNumber = view.add_blocked_number_edittext.value
                         if (originalNumber != null && newBlockedNumber != originalNumber.number) {
                             activity.deleteBlockedNumber(originalNumber.number)
                         }
 
                         if (newBlockedNumber.isNotEmpty()) {
+                            // in case the user also added a '.' in the pattern, remove it
+                            if (newBlockedNumber.contains(".*")) {
+                                newBlockedNumber = newBlockedNumber.replace(".*", "*")
+                            }
                             activity.addBlockedNumber(newBlockedNumber)
                         }
 

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -990,7 +990,20 @@ fun Context.isNumberBlocked(number: String, blockedNumbers: ArrayList<BlockedNum
     }
 
     val numberToCompare = number.trimToComparableNumber()
-    return blockedNumbers.map { it.numberToCompare }.contains(numberToCompare) || blockedNumbers.map { it.number }.contains(numberToCompare)
+    return blockedNumbers.any { numberToCompare in it.numberToCompare || numberToCompare in it.number } || isNumberBlockedByPattern(number, blockedNumbers)
+}
+
+fun Context.isNumberBlockedByPattern(number: String, blockedNumbers: ArrayList<BlockedNumber> = getBlockedNumbers()): Boolean {
+    for (blockedNumber in blockedNumbers) {
+        val num = blockedNumber.number
+        if (num.contains("*")) {
+            val pattern = num.replace("+", "\\+").replace("*", ".*")
+            if (number.matches(pattern.toRegex())) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 fun Context.copyToClipboard(text: String) {

--- a/commons/src/main/res/layout/dialog_add_blocked_number.xml
+++ b/commons/src/main/res/layout/dialog_add_blocked_number.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dialog_holder"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -11,7 +12,9 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/activity_margin"
         android:layout_marginEnd="@dimen/activity_margin"
-        android:hint="@string/number">
+        android:hint="@string/number"
+        app:helperText="@string/add_blocked_number_helper_text"
+        app:helperTextEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/add_blocked_number_edittext"

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">هل تريد بالتأكيد حظر \"%s\"؟</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">المفضلة</string>
     <string name="add_favorites">إضافة مفضلة</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Sevimlilər</string>

--- a/commons/src/main/res/values-be/strings.xml
+++ b/commons/src/main/res/values-be/strings.xml
@@ -219,6 +219,7 @@
     <string name="block_confirmation">Заблакаваць \"%s\"\?</string>
     <string name="block_unknown_calls">Блакаваць выклікі ад невядомых кантактаў</string>
     <string name="block_unknown_messages">Блакаваць паведамленні ад невядомых кантактаў</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <string name="favorites">Абраныя</string>
     <string name="add_favorites">Дадаць абранае</string>
     <string name="add_to_favorites">Дадаць у абранае</string>

--- a/commons/src/main/res/values-bg/strings.xml
+++ b/commons/src/main/res/values-bg/strings.xml
@@ -106,6 +106,7 @@
     <string name="block_confirmation">Сигурни ли сте, че искате да блокирате \"%s\"\?</string>
     <string name="block_unknown_calls">Блокиране на повиквания от незапазени контакти</string>
     <string name="block_unknown_messages">Блокиране на съобщения от незапазени контакти</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Любими</string>
     <string name="add_favorites">Добави любими</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Favorites</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Segur que voleu bloquejar «%s»\?</string>
     <string name="block_unknown_calls">Bloqueja les trucades de contactes no emmagatzemats</string>
     <string name="block_unknown_messages">Bloqueja els missatges dels contactes no emmagatzemats</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Preferits</string>
     <string name="add_favorites">Afegeix preferits</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -106,6 +106,7 @@
     <string name="block_confirmation">Jste si jistí, že chcete zablokovat „%s“\?</string>
     <string name="block_unknown_calls">Blokovat volání z neznámých čísel</string>
     <string name="block_unknown_messages">Blokovat zprávy z neznámých čísel</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Oblíbené</string>
     <string name="add_favorites">Přidat oblíbené</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Ffefrynnau</string>
     <string name="add_favorites">Ychwanegu ffefryn</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Er du sikker på at du vil blokere \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Bogmærker</string>
     <string name="add_favorites">Tilføj bogmærker</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Soll „%s“ blockiert werden\?</string>
     <string name="block_unknown_calls">Anrufe von nicht gespeicherten Kontakten blockieren</string>
     <string name="block_unknown_messages">Nachrichten von nicht gespeicherten Kontakten blockieren</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoriten</string>
     <string name="add_favorites">Favoriten hinzufügen</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Σίγουρα να αποκλειστεί ο \"%s\"?</string>
     <string name="block_unknown_calls">Αποκλεισμός κλήσεων από μη αποθηκευμένες επαφές</string>
     <string name="block_unknown_messages">Αποκλεισμός μηνυμάτων από μη αποθηκευμένες επαφές</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Αγαπημένα</string>
     <string name="add_favorites">Προσθήκη αγαπημένων</string>

--- a/commons/src/main/res/values-eo/strings.xml
+++ b/commons/src/main/res/values-eo/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favorites</string>
     <string name="add_favorites">Add favorites</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">¿Estás seguro de que quieres bloquear a \"%s\"?</string>
     <string name="block_unknown_calls">Bloquear llamadas de contactos no almacenados</string>
     <string name="block_unknown_messages">Bloquear los mensajes de los contactos no almacenados</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoritos</string>
     <string name="add_favorites">Añadir a favoritos</string>

--- a/commons/src/main/res/values-et/strings.xml
+++ b/commons/src/main/res/values-et/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Kas sa oled kindel, et soovid blokeerida „%s“ telefoninumbrit\?</string>
     <string name="block_unknown_calls">Blokeeri kõned, kui helistaja pole aadressiraamatus</string>
     <string name="block_unknown_messages">Blokeeri sõnumid, kui saatja pole aadressiraamatus</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Lemmikud</string>
     <string name="add_favorites">Lisa lemmikuks</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -107,6 +107,7 @@
     <string name="block_confirmation">Ziur zaude \"%s\" blokeatu nahi duzula?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Gogokoak</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">موردعلاقه‌ها</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Haluatko varmasti estää numeron \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Suosikit</string>
     <string name="add_favorites">Lisää suosikkeja</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Voulez-vous vraiment bloquer « %s » \?</string>
     <string name="block_unknown_calls">Bloquer les appels des contacts non enregistrés</string>
     <string name="block_unknown_messages">Bloquer les messages des contacts non enregistrés</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoris</string>
     <string name="add_favorites">Ajouter des favoris</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Seguro que queres bloquear a \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoritos</string>
     <string name="add_favorites">Engadir a favoritos</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favorites</string>
     <string name="add_favorites">Add favorites</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoriti</string>
     <string name="add_favorites">Dodaj favorite</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Biztos, hogy letiltja a következőt: „%s”\?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Kedvencek</string>
     <string name="add_favorites">Kedvencek hozzáadása</string>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Yakin untuk memblokir \"%s\"\?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favorit</string>
     <string name="add_favorites">Tambah favorit</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Sei sicuro/a di volere bloccare «%s»\?</string>
     <string name="block_unknown_calls">Blocca le chiamate dai contatti non memorizzati</string>
     <string name="block_unknown_messages">Blocca i messaggi dei contatti non memorizzati</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Preferiti</string>
     <string name="add_favorites">Aggiungi preferiti</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">האם לחסום את \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">מועדפים</string>
     <string name="add_favorites">הוספה למועדפים</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">本当に\"%s\"をブロックしますか？</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">お気に入り</string>
     <string name="add_favorites">お気に入りを追加</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">즐겨찾기</string>
     <string name="add_favorites">즐겨찾기 추가</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Ar tikrai norite užblokuoti „%s“\?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Mėgstami</string>
     <string name="add_favorites">Pridėti mėgstamus</string>

--- a/commons/src/main/res/values-ml/strings.xml
+++ b/commons/src/main/res/values-ml/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Favorites</string>

--- a/commons/src/main/res/values-nb-rNO/strings.xml
+++ b/commons/src/main/res/values-nb-rNO/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoritter</string>
     <string name="add_favorites">Legg til favoritter</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Nummer \"%s\" echt blokkeren\?</string>
     <string name="block_unknown_calls">Oproepen van onopgeslagen contacten blokkeren</string>
     <string name="block_unknown_messages">Berichten van onopgeslagen contacten blokkeren</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favorieten</string>
     <string name="add_favorites">Favorieten toevoegen</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Czy zablokować „%s”\?</string>
     <string name="block_unknown_calls">Blokuj połączenia od niezapisanych kontaktów</string>
     <string name="block_unknown_messages">Blokuj wiadomości od niezapisanych kontaktów</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Ulubione</string>
     <string name="add_favorites">Dodaj ulubione</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Tem certeza que deseja bloquear \"%s\"?</string>
     <string name="block_unknown_calls">Bloquear chamadas de contatos não salvos</string>
     <string name="block_unknown_messages">Bloquear mensagens de contatos não salvos</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoritos</string>
     <string name="add_favorites">Adicionar favoritos</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Tem a certeza de que pretende bloquear \"%s\"\?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoritos</string>
     <string name="add_favorites">Adicionar favoritos</string>

--- a/commons/src/main/res/values-ro/strings.xml
+++ b/commons/src/main/res/values-ro/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Eşti sigur că vrei să îl blochezi pe \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favorite</string>
     <string name="add_favorites">Adaugă favorite</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Заблокировать \"%s\"?</string>
     <string name="block_unknown_calls">Блокировать вызовы от несохранённых контактов</string>
     <string name="block_unknown_messages">Блокировать сообщения от несохранённых контактов</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Избранное</string>
     <string name="add_favorites">Добавить избранное</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Ste si istý, že chcete zablokovať \"%s\"?</string>
     <string name="block_unknown_calls">Blokovať volania od neuložených kontaktov</string>
     <string name="block_unknown_messages">Blokovať správy od neuložených kontaktov</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Obľúbené</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -109,7 +109,7 @@
     <string name="block_confirmation">Ste si istý, že chcete zablokovať \"%s\"?</string>
     <string name="block_unknown_calls">Blokovať volania od neuložených kontaktov</string>
     <string name="block_unknown_messages">Blokovať správy od neuložených kontaktov</string>
-    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
+    <string name="add_blocked_number_helper_text">Zadajte číslo, alebo vzor (napr. *12345*, +421*8888) pre blokovanie každého, kto spadá pod daný vzor.</string>
 
     <!-- Favorites -->
     <string name="favorites">Obľúbené</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Priljubljeno</string>
     <string name="add_favorites">Dodaj priljubljene</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Омиљено</string>
     <string name="add_favorites">Додај омиљене</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Är du säker på att du vill blockera \"%s\"?</string>
     <string name="block_unknown_calls">Blockera samtal från okända nummer</string>
     <string name="block_unknown_messages">Blockera meddelanden från okända nummer</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoriter</string>
     <string name="add_favorites">Lägg till favoriter</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">\"%s\" ஐத் தடுக்க விரும்புகிறீர்களா?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">பிடித்தவை</string>
     <string name="add_favorites">பிடித்தவற்றைச் சேர்</string>

--- a/commons/src/main/res/values-th/strings.xml
+++ b/commons/src/main/res/values-th/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Favorites</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">\"%s\" gerçekten engellensin mi?</string>
     <string name="block_unknown_calls">Kayıtlı olmayan kişilerden gelen aramaları engelle</string>
     <string name="block_unknown_messages">Kayıtlı olmayan kişilerden gelen mesajları engelle</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Favoriler</string>
     <string name="add_favorites">Favori ekle</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Ви впевнені що хочете заблокувати \"%s\"?</string>
     <string name="block_unknown_calls">Блокувати дзвінки від не збережених контактів</string>
     <string name="block_unknown_messages">Блокувати повідомлення від не збережених контактів</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">Улюблене</string>
     <string name="add_favorites">Додати улюблене</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Yêu thích</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">您确定要将 \"%s\" 添加到黑名单吗？</string>
     <string name="block_unknown_calls">拦截来自未存储联系人的通话</string>
     <string name="block_unknown_messages">拦截来自未存储联系人的消息</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">收藏</string>
     <string name="add_favorites">添加收藏</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -105,6 +105,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
     <!-- Favorites -->
     <string name="favorites">我的最愛</string>
     <string name="add_favorites">添加我的最愛</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="block_confirmation">Are you sure you want to block \"%s\"?</string>
     <string name="block_unknown_calls">Block calls from not stored contacts</string>
     <string name="block_unknown_messages">Block messages from not stored contacts</string>
+    <string name="add_blocked_number_helper_text">Enter a number or a pattern (e.g. *12345*, +1*8888) to block all calls matching the pattern.</string>
 
     <!-- Favorites -->
     <string name="favorites">Favorites</string>


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/36371707/189494793-0fb6c8b7-b59b-4a2b-8eb2-1fc4fdccee91.png" width=264 /> <img src="https://user-images.githubusercontent.com/36371707/189494808-a5a039fb-5b6e-4b53-a5ce-a4c626876f9e.png" width=264 />

### Examples: 
**+1*1818**: All numbers starting with +1 and ending with 1818 should be blocked.
***9999**: All numbers ending with 9999 should be blocked.

### Notes:
- Simple apps are supposed to reject/block a `number` when [isNumberBlockedByPattern(number)](https://github.com/Naveen3Singh/Simple-Commons/blob/ab25830c4b2a499c31610a490b48c2fcce5bafad/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt#L996) returns `true`
- For simplicity, these number patterns are still stored in the android [BlockedNumber DB](https://developer.android.com/reference/android/provider/BlockedNumberContract) instead of an in-app DB

<details>
<summary>Alternative</summary>

Another way to do this would be to provide a spinner (with below options) plus an input field for the _number_:

Block all calls:
 - Starting with _number_
 - Ending with _number_
 - Starting and ending with _number_ 
 
seems slightly easier from a user's perspective but '*' works too

</details>
