### PR TITLE
Added Punjabi language name strings

### DIFF
--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -956,6 +956,8 @@
     <string name="translation_dutch">Dutch</string>
     <string name="translation_polish">Polish</string>
     <string name="translation_portuguese">Portuguese</string>
+    <string name="translation_punjabi_in">Punjabi (Gurmukhi)</string>
+    <string name="translation_punjabi_pk">Punjabi (Shahmukhi)</string>
     <string name="translation_romanian">Romanian</string>
     <string name="translation_russian">Russian</string>
     <string name="translation_slovak">Slovak</string>


### PR DESCRIPTION
I am in the process of translating the Simple Mobile Tools to Punjabi, and intend to add keyboard layouts to the Simple Keyboard App. As I understand it, the language name options come from here.

Punjabi (Gurmukhi) corresponds to pa or pa-IN and Punjabi (Shahmukhi) corresponds to pa-PK. These are the two writing systems used for the language (similar situation to Chinese).