### PR TITLE
Update status bar height using WindowInsetCompat API

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -36,6 +36,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.util.Pair
 import androidx.core.view.ScrollingView
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.simplemobiletools.commons.R
@@ -227,11 +228,13 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, navigationBarHeight)
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = statusBarHeight
             } else {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.removeBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, 0)
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = 0
+            }
+            onApplyWindowInsets {
+                val insets = it.getInsets(WindowInsetsCompat.Type.systemBars())
+                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = insets.top
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -32,6 +32,7 @@ import androidx.biometric.BiometricPrompt
 import androidx.biometric.auth.AuthPromptCallback
 import androidx.biometric.auth.AuthPromptHost
 import androidx.biometric.auth.Class2BiometricAuthPrompt
+import androidx.core.view.WindowInsetsCompat
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -1715,4 +1716,11 @@ fun BaseSimpleActivity.getTempFile(folderName: String, fileName: String): File? 
     }
 
     return File(folder, fileName)
+}
+
+fun Activity.onApplyWindowInsets(callback: (WindowInsetsCompat) -> Unit) {
+    window.decorView.setOnApplyWindowInsetsListener { v, insets ->
+        callback(WindowInsetsCompat.toWindowInsetsCompat(insets))
+        insets
+    }
 }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/561 across all affected apps.

I could not reproduce it on any other device, only one running Android 12.

Before we used the following:
```kotlin
val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
if (resourceId > 0) {
    statusBarHeight = resources.getDimensionPixelSize(resourceId)
}
```
but evidently, that's no longer reliable. The `onApplyWindowInsets` function is an extension because it can be used by other apps (e.g. ThreadActivity in Simple-SMS-Messenger)