### PR TITLE
Update status bar height using window inset API

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -227,17 +227,23 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
         if (useTransparentNavigation) {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
+                updateTopBottomInsets(statusBarHeight, navigationBarHeight)
                 onApplyWindowInsets {
                     val insets = it.getInsets(WindowInsetsCompat.Type.systemBars())
-                    nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, insets.bottom)
-                    (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = insets.top
+                    updateTopBottomInsets(insets.top, insets.bottom)
                 }
             } else {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.removeBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
-                nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, 0)
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = 0
+                updateTopBottomInsets(0, 0)
             }
         }
+    }
+
+    private fun updateTopBottomInsets(statusBarHeight: Int, navigationBarHeight: Int) {
+        nestedView?.run {
+            setPadding(paddingLeft, paddingTop, paddingRight, navigationBarHeight)
+        }
+        (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = statusBarHeight
     }
 
     // colorize the top toolbar and statusbar at scrolling down a bit

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -227,14 +227,15 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
         if (useTransparentNavigation) {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
-                nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, navigationBarHeight)
+                onApplyWindowInsets {
+                    val insets = it.getInsets(WindowInsetsCompat.Type.systemBars())
+                    nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, insets.bottom)
+                    (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = insets.top
+                }
             } else {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.removeBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, 0)
-            }
-            onApplyWindowInsets {
-                val insets = it.getInsets(WindowInsetsCompat.Type.systemBars())
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = insets.top
+                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = 0
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -36,6 +36,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.util.Pair
 import androidx.core.view.ScrollingView
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.simplemobiletools.commons.R
@@ -227,11 +228,13 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, navigationBarHeight)
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = statusBarHeight
             } else {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.removeBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 nestedView?.setPadding(nestedView!!.paddingLeft, nestedView!!.paddingTop, nestedView!!.paddingRight, 0)
-                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = 0
+            }
+            onApplyWindowInsets {
+                val insets = it.getInsets(WindowInsetsCompat.Type.systemBars())
+                (mainCoordinatorLayout?.layoutParams as? FrameLayout.LayoutParams)?.topMargin = insets.top
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -32,6 +32,7 @@ import androidx.biometric.BiometricPrompt
 import androidx.biometric.auth.AuthPromptCallback
 import androidx.biometric.auth.AuthPromptHost
 import androidx.biometric.auth.Class2BiometricAuthPrompt
+import androidx.core.view.WindowInsetsCompat
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -1715,4 +1716,12 @@ fun BaseSimpleActivity.getTempFile(folderName: String, fileName: String): File? 
     }
 
     return File(folder, fileName)
+}
+
+fun Activity.onApplyWindowInsets(callback: (WindowInsetsCompat) -> Unit) {
+    window.decorView.setOnApplyWindowInsetsListener { view, insets ->
+        callback(WindowInsetsCompat.toWindowInsetsCompat(insets))
+        view.onApplyWindowInsets(insets)
+        insets
+    }
 }


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-SMS-Messenger/issues/561 across all affected apps and doesn't have side effects like the previous (https://github.com/SimpleMobileTools/Simple-Commons/pull/1598) fix (compare the extension function)

~I could not reproduce it on any other device, only one running Android 12.~
I was able to reproduce it on devices that don't use the default status bar height (e.g. devices with a bigger notch). It also happens if you change the camera cutout in developer options as that changes the status bar height. This issue happens with the navigation bar too on devices with unique configurations hence we are updating the scroll view padding as well.

 The `onApplyWindowInsets` function is an extension because it can be used by other apps (e.g. ThreadActivity in Simple-SMS-Messenger)

**Before vs After:**

<img src="https://user-images.githubusercontent.com/36371707/212685496-aff81e9a-331b-4880-9284-777f85d96e58.png" width=264/> <img src="https://user-images.githubusercontent.com/36371707/212685146-76af961b-4c8d-422c-ae17-302c268aa199.png" width=264/>

_tested on all the devices I could find/create_
