### PR TITLE
Fixed checking blocked numbers

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -1010,7 +1010,7 @@ fun Context.isNumberBlocked(number: String, blockedNumbers: ArrayList<BlockedNum
     }
 
     val numberToCompare = number.trimToComparableNumber()
-    return blockedNumbers.any { numberToCompare in it.numberToCompare || numberToCompare in it.number } || isNumberBlockedByPattern(number, blockedNumbers)
+    return blockedNumbers.any { numberToCompare == it.numberToCompare || numberToCompare == it.number } || isNumberBlockedByPattern(number, blockedNumbers)
 }
 
 fun Context.isNumberBlockedByPattern(number: String, blockedNumbers: ArrayList<BlockedNumber> = getBlockedNumbers()): Boolean {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -988,7 +988,9 @@ fun Context.getBlockedNumbers(): ArrayList<BlockedNumber> {
 fun Context.addBlockedNumber(number: String) {
     ContentValues().apply {
         put(BlockedNumbers.COLUMN_ORIGINAL_NUMBER, number)
-        put(BlockedNumbers.COLUMN_E164_NUMBER, PhoneNumberUtils.normalizeNumber(number))
+        if (number.isPhoneNumber()) {
+            put(BlockedNumbers.COLUMN_E164_NUMBER, PhoneNumberUtils.normalizeNumber(number))
+        }
         try {
             contentResolver.insert(BlockedNumbers.CONTENT_URI, this)
         } catch (e: Exception) {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -258,6 +258,10 @@ fun String.normalizeString() = Normalizer.normalize(this, Normalizer.Form.NFD).r
 
 // if we are comparing phone numbers, compare just the last 9 digits
 fun String.trimToComparableNumber(): String {
+    // don't trim if it's not a phone number
+    if (!this.matches("^[0-9+\\-\\)\\( *#]+\$".toRegex())) {
+        return this
+    }
     val normalizedNumber = this.normalizeString()
     val startIndex = Math.max(0, normalizedNumber.length - 9)
     return normalizedNumber.substring(startIndex)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/String.kt
@@ -256,10 +256,15 @@ fun String.getAvailableStorageB(): Long {
 // remove diacritics, for example č -> c
 fun String.normalizeString() = Normalizer.normalize(this, Normalizer.Form.NFD).replace(normalizeRegex, "")
 
+// checks if string is a phone number
+fun String.isPhoneNumber(): Boolean {
+    return this.matches("^[0-9+\\-\\)\\( *#]+\$".toRegex())
+}
+
 // if we are comparing phone numbers, compare just the last 9 digits
 fun String.trimToComparableNumber(): String {
     // don't trim if it's not a phone number
-    if (!this.matches("^[0-9+\\-\\)\\( *#]+\$".toRegex())) {
+    if (!this.isPhoneNumber()) {
         return this
     }
     val normalizedNumber = this.normalizeString()


### PR DESCRIPTION
In Simple SMS Messenger, I had a situation that few conversations were missing. 

I've found out, that function checking for blocked numbers wasn't working as it should, e.g. (random example, for privacy reasons) I had blocked number `600600491`, and it was blocking conversation with number `491`.

Fix was to change string comparison from contains to equality. However, there is also the trim function and it also had to be changed. It's because, when you're trimming a number like `+48600600491` to `600600491` it's perfectly fine, but numbers can also be "SPAMMING CORP", and trimming it to "MING CORP" would lead to not blocking the conversation. That's why I decided to check by regex if the number is the real number, not just a name. I assume, that real numbers contains only numbers, `-`, `(`, `)`, `*` and `#`.

I've checked the code in Simple SMS Messenger, and it seems to work fine with both edge cases I've provided.