### PR TITLE
fix: remove showTabs pref from commons

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
@@ -510,11 +510,6 @@ open class BaseConfig(val context: Context) {
                 SHOW_ADDRESSES_FIELD or SHOW_EVENTS_FIELD or SHOW_NOTES_FIELD or SHOW_GROUPS_FIELD or SHOW_CONTACT_SOURCE_FIELD
         )
         set(showContactFields) = prefs.edit().putInt(SHOW_CONTACT_FIELDS, showContactFields).apply()
-
-    var showTabs: Int
-        get() = prefs.getInt(SHOW_TABS, ALL_TABS_MASK)
-        set(showTabs) = prefs.edit().putInt(SHOW_TABS, showTabs).apply()
-
     var showDialpadButton: Boolean
         get() = prefs.getBoolean(SHOW_DIALPAD_BUTTON, true)
         set(showDialpadButton) = prefs.edit().putBoolean(SHOW_DIALPAD_BUTTON, showDialpadButton).apply()

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -590,7 +590,6 @@ const val PHOTO_UNCHANGED = 4
 const val ON_CLICK_CALL_CONTACT = 1
 const val ON_CLICK_VIEW_CONTACT = 2
 const val ON_CLICK_EDIT_CONTACT = 3
-const val ALL_TABS_MASK = TAB_CONTACTS or TAB_FAVORITES or TAB_GROUPS
 
 // apps with special handling
 const val TELEGRAM_PACKAGE = "org.telegram.messenger"


### PR DESCRIPTION
This preference should live in the individual config file of each app.