### PR TITLE
Delete hidden files using casual method

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -702,19 +702,19 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
     }
 
     val firstFile = files.first()
-    handleSAFDialog(firstFile.path) {
+    val firstFilePath = firstFile.path
+    handleSAFDialog(firstFilePath) {
         if (!it) {
             return@handleSAFDialog
         }
 
-        checkManageMediaOrHandleSAFDialogSdk30(firstFile.path) {
+        checkManageMediaOrHandleSAFDialogSdk30(firstFilePath) {
             if (!it) {
                 return@checkManageMediaOrHandleSAFDialogSdk30
             }
 
             val recycleBinPath = firstFile.isRecycleBinPath(this)
-            val containsNoMedia = firstFile.path.doesThisOrParentHaveNoMedia(HashMap(), null)
-            if (canManageMedia() && !recycleBinPath && !containsNoMedia) {
+            if (canManageMedia() && !recycleBinPath && !firstFilePath.doesThisOrParentHaveNoMedia(HashMap(), null)) {
                 val fileUris = getFileUrisFromFileDirItems(files)
 
                 deleteSDK30Uris(fileUris) { success ->

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -713,7 +713,8 @@ fun BaseSimpleActivity.deleteFilesBg(files: List<FileDirItem>, allowDeleteFolder
             }
 
             val recycleBinPath = firstFile.isRecycleBinPath(this)
-            if (canManageMedia() && !recycleBinPath) {
+            val containsNoMedia = firstFile.path.doesThisOrParentHaveNoMedia(HashMap(), null)
+            if (canManageMedia() && !recycleBinPath && !containsNoMedia) {
                 val fileUris = getFileUrisFromFileDirItems(files)
 
                 deleteSDK30Uris(fileUris) { success ->


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Gallery/issues/2759

This is because the usual `MediaStore.createDeleteRequest()` doesn't seem to work for files that are hidden. 

**Note:** If a folder's `.nomedia` file is deleted i.e. unhidden, deleting any media inside the folder will still fail if MediaStore isn't notified about the `.nomedia` deletion. To fix that, we must properly update MediaStore when we hide/unhide a folder.