### PR TITLE
Fix viewing organization contacts

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/ContactsHelper.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/ContactsHelper.kt
@@ -735,9 +735,9 @@ class ContactsHelper(val context: Context) {
                 var suffix = ""
                 var mimetype = cursor.getStringValue(Data.MIMETYPE)
 
-                // if first line is an Organization type contact, go to next line
+                // if first line is an Organization type contact, go to next line if available
                 if (mimetype != CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE) {
-                    if (cursor.moveToNext()) {
+                    if (!cursor.isLast() && cursor.moveToNext()) {
                         mimetype = cursor.getStringValue(Data.MIMETYPE)
                     }
                 }


### PR DESCRIPTION
Fix crash when tapping on a contact without name but only with organization set.

To reproduce create a contact like the VCARD below. Note that importing this VCARD with Simple-Contacts "falsifies" the contact by setting non-empty "FN:" field (crash does not occur then), so I imported the VCARD to a CARDDAV server and synced the contact to my phone using DAVx5.

BEGIN:VCARD
PRODID:-//CyrusIMAP.org//Cyrus 3.9.0-alpha0-334-g8c072af647-fm-202303..//EN
VERSION:3.0
UID:79785bc9-e1e6-483e-b2cc-6a288217c8d9
N:;;;;
FN: 
TEL;TYPE=work:1234567890
ORG:TestCompanyName;
NOTE:
NICKNAME:
adr0.X-ABADR:us
adr0.ADR;TYPE=work:;;123 45th St;TestCity;WA;99999;
TITLE:
REV:20230416T133404Z
EMAIL;TYPE=work;TYPE=pref:DummyEmail@TestCompanyName.com
END:VCARD