### PR TITLE
Fix window inset issues

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -158,6 +158,7 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
                 hideKeyboard()
                 finish()
             }
+
             else -> return super.onOptionsItemSelected(item)
         }
         return true
@@ -228,13 +229,13 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 updateTopBottomInsets(statusBarHeight, navigationBarHeight)
+                onApplyWindowInsets {
+                    val insets = it.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime())
+                    updateTopBottomInsets(insets.top, insets.bottom)
+                }
             } else {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.removeBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 updateTopBottomInsets(0, 0)
-            }
-            onApplyWindowInsets {
-                val insets = it.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime())
-                updateTopBottomInsets(insets.top, insets.bottom)
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/BaseSimpleActivity.kt
@@ -229,6 +229,7 @@ abstract class BaseSimpleActivity : AppCompatActivity() {
             if (navigationBarHeight > 0 || isUsingGestureNavigation()) {
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility.addBit(View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION)
                 updateTopBottomInsets(statusBarHeight, navigationBarHeight)
+                // Don't touch this. Window Inset API often has a domino effect and things will most likely break.
                 onApplyWindowInsets {
                     val insets = it.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime())
                     updateTopBottomInsets(insets.top, insets.bottom)


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/SimpleMobileTools/Simple-Commons/pull/1667#issuecomment-1537537441

Calling `View.onApplyWindowInsets` on `decorView` leads to this weird effect in landscape mode. The insets are applied twice because `View.onApplyWindowInsets` method is called by our extension function to fix [some other issues](https://github.com/SimpleMobileTools/Simple-Commons/pull/1598#issuecomment-1383234211).

To fix this issue, we avoid calling onApplyWindowInsets unnecessarily.