### PR TITLE
fix #530

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -550,10 +550,7 @@ fun BaseSimpleActivity.launchCallIntent(recipient: String, handle: PhoneAccountH
             }
 
             if (isDefaultDialer()) {
-                val packageName = when(BuildConfig.DEBUG) {
-                    true -> "com.simplemobiletools.dialer.debug"
-                    false -> "com.simplemobiletools.dialer"
-                }
+                val packageName = if (BuildConfig.DEBUG) "com.simplemobiletools.dialer.debug" else "com.simplemobiletools.dialer"
                 val className = "com.simplemobiletools.dialer.activities.DialerActivity"
                 this.setClassName(packageName, className)
             }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -552,7 +552,7 @@ fun BaseSimpleActivity.launchCallIntent(recipient: String, handle: PhoneAccountH
             if (isDefaultDialer()) {
                 val packageName = if (BuildConfig.DEBUG) "com.simplemobiletools.dialer.debug" else "com.simplemobiletools.dialer"
                 val className = "com.simplemobiletools.dialer.activities.DialerActivity"
-                this.setClassName(packageName, className)
+                setClassName(packageName, className)
             }
 
             launchActivityIntent(this)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -36,6 +36,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.simplemobiletools.commons.BuildConfig
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
 import com.simplemobiletools.commons.dialogs.*
@@ -537,7 +538,6 @@ fun Activity.launchViewContactIntent(uri: Uri) {
         launchActivityIntent(this)
     }
 }
-
 fun BaseSimpleActivity.launchCallIntent(recipient: String, handle: PhoneAccountHandle? = null) {
     handlePermission(PERMISSION_CALL_PHONE) {
         val action = if (it) Intent.ACTION_CALL else Intent.ACTION_DIAL
@@ -546,6 +546,15 @@ fun BaseSimpleActivity.launchCallIntent(recipient: String, handle: PhoneAccountH
 
             if (handle != null) {
                 putExtra(TelecomManager.EXTRA_PHONE_ACCOUNT_HANDLE, handle)
+            }
+
+            if (isDefaultDialer()) {
+                val packageName = when(BuildConfig.DEBUG) {
+                    true -> "com.simplemobiletools.dialer.debug"
+                    false -> "com.simplemobiletools.dialer"
+                }
+                val className = "com.simplemobiletools.dialer.activities.DialerActivity"
+                this.setClassName(packageName, className)
             }
 
             launchActivityIntent(this)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Activity.kt
@@ -538,6 +538,7 @@ fun Activity.launchViewContactIntent(uri: Uri) {
         launchActivityIntent(this)
     }
 }
+
 fun BaseSimpleActivity.launchCallIntent(recipient: String, handle: PhoneAccountHandle? = null) {
     handlePermission(PERMISSION_CALL_PHONE) {
         val action = if (it) Intent.ACTION_CALL else Intent.ACTION_DIAL


### PR DESCRIPTION
Even though our Dialer app was configured to be the default app, when calling a number, the device used to prompt to select the app.

Adding this fix, where we check if our app is the default dialer or not. If it is, we explicitly open our app when calling the `launchCallIntent`. 