### PR TITLE
fix #598

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/MyContactsContentProvider.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/MyContactsContentProvider.kt
@@ -87,8 +87,19 @@ class MyContactsContentProvider {
                             val stringsToken = object : TypeToken<ArrayList<String>>() {}.type
                             val birthdays = Gson().fromJson<ArrayList<String>>(birthdaysJson, stringsToken) ?: ArrayList()
                             val anniversaries = Gson().fromJson<ArrayList<String>>(anniversariesJson, stringsToken) ?: ArrayList()
-                            val names = name.split(" ")
-                            val firstName = names.firstOrNull() ?: ""
+
+                            // Modified how names is calculated because of Issue #598
+                            var names:  List<String>
+                            if(name.contains(",")) {
+                                names = name.split(",")
+                            } else {
+                                names = name.split(" ")
+                            }
+
+                            var firstName = names.firstOrNull() ?: ""
+                            if(name.contains(",")) {
+                                firstName += ", "
+                            }
                             val middleName = if (names.size == 3) names[2] else ""
                             val surname = if (names.size > 1) {
                                 names.lastOrNull() ?: ""


### PR DESCRIPTION
In `MyContactsContentProvider` name was calculated by blindly splitting the name obtained by using space character as the separator.

```
var firstName = names.firstOrNull() ?: ""
val middleName = if (names.size == 3) names[2] else ""
val surname = if (names.size > 1) {
    names.lastOrNull() ?: ""
} else {
    ""
}
```

This caused a name Like **Google Company, Android Develooper** to be displayed as "Google Developer" rather than the original name.

So, the fix was to check if a comma was present in the name or not. If it is present, split using a comma else split using Space

@tibbi please check if we need to consider any other cases