### PR TITLE
Fix LICENSE_ZIP4J text references

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/activities/LicenseActivity.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/activities/LicenseActivity.kt
@@ -91,6 +91,6 @@ class LicenseActivity : BaseSimpleActivity() {
         License(LICENSE_M3U_PARSER, R.string.m3u_parser_title, R.string.m3u_parser_text, R.string.m3u_parser_url),
         License(LICENSE_ANDROID_LAME, R.string.android_lame_title, R.string.android_lame_text, R.string.android_lame_url),
         License(LICENSE_PDF_VIEWER, R.string.pdf_viewer_title, R.string.pdf_viewer_text, R.string.pdf_viewer_url),
-        License(LICENSE_ZIP4J, R.string.pdf_viewer_title, R.string.pdf_viewer_text, R.string.pdf_viewer_url)
+        License(LICENSE_ZIP4J, R.string.zip4j_title, R.string.zip4j_text, R.string.zip4j_url)
     )
 }


### PR DESCRIPTION
I forgot to update string references for `LICENSE_ZIP4J` in my previous PR (#1724 ). This fixes that.