### PR TITLE
Update PermissionRequiredDialog.kt to support custom callbacks.

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/PermissionRequiredDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/PermissionRequiredDialog.kt
@@ -4,11 +4,15 @@ import android.app.Activity
 import androidx.appcompat.app.AlertDialog
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.extensions.getAlertDialogBuilder
-import com.simplemobiletools.commons.extensions.openNotificationSettings
 import com.simplemobiletools.commons.extensions.setupDialogStuff
 import kotlinx.android.synthetic.main.dialog_message.view.*
 
-class PermissionRequiredDialog(val activity: Activity, textId: Int) {
+class PermissionRequiredDialog(
+    val activity: Activity,
+    textId: Int,
+    private val positiveActionCallback: () -> Unit,
+    private val negativeActionCallback: (() -> Unit)? = null
+) {
     private var dialog: AlertDialog? = null
 
     init {
@@ -16,8 +20,8 @@ class PermissionRequiredDialog(val activity: Activity, textId: Int) {
         view.message.text = activity.getString(textId)
 
         activity.getAlertDialogBuilder()
-            .setPositiveButton(R.string.grant_permission) { dialog, which -> activity.openNotificationSettings() }
-            .setNegativeButton(R.string.cancel, null).apply {
+            .setPositiveButton(R.string.grant_permission) { _, _ -> positiveActionCallback() }
+            .setNegativeButton(R.string.cancel) { _, _ -> negativeActionCallback?.invoke() }.apply {
                 val title = activity.getString(R.string.permission_required)
                 activity.setupDialogStuff(view, this, titleText = title) { alertDialog ->
                     dialog = alertDialog

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Context.kt
@@ -1089,3 +1089,12 @@ fun Context.openNotificationSettings() {
         startActivity(intent)
     }
 }
+
+@RequiresApi(Build.VERSION_CODES.S)
+fun Context.openRequestExactAlarmSettings() {
+    if (isSPlus()) {
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+        intent.putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        startActivity(intent)
+    }
+}


### PR DESCRIPTION
Update Permission Required Dialog to support different callbacks when granting or denying permission.  I added this one specifically y to allow showing the Request Schedule Exact Alarm Permission for API S and Above. 

> 

I added the extension to openRequestExactAlarmSettings, following the same pattern as the OpenNotificationSettings extension. 