### PR TITLE
Fix crash with TabLayouts and their tabs

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/BiometricIdTab.kt
@@ -2,7 +2,6 @@ package com.simplemobiletools.commons.views
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import androidx.biometric.auth.AuthPromptHost
 import androidx.constraintlayout.widget.ConstraintLayout
 import com.simplemobiletools.commons.databinding.TabBiometricIdBinding
@@ -14,9 +13,10 @@ import com.simplemobiletools.commons.interfaces.SecurityTab
 class BiometricIdTab(context: Context, attrs: AttributeSet) : ConstraintLayout(context, attrs), SecurityTab {
     private lateinit var hashListener: HashListener
     private lateinit var biometricPromptHost: AuthPromptHost
-    val binding = TabBiometricIdBinding.inflate(LayoutInflater.from(context), this, true)
+    private lateinit var binding: TabBiometricIdBinding
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = TabBiometricIdBinding.bind(this)
         context.updateTextColors(binding.biometricLockHolder)
         val textColor = if (context.isWhiteTheme()) {
             DARK_GREY

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/FingerprintTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/FingerprintTab.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Handler
 import android.provider.Settings
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.widget.RelativeLayout
 import androidx.biometric.auth.AuthPromptHost
 import com.github.ajalt.reprint.core.AuthenticationFailureReason
@@ -24,10 +23,11 @@ class FingerprintTab(context: Context, attrs: AttributeSet) : RelativeLayout(con
 
     lateinit var hashListener: HashListener
 
-    private val binding = TabFingerprintBinding.inflate(LayoutInflater.from(context), this, true)
+    private lateinit var binding: TabFingerprintBinding
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = TabFingerprintBinding.bind(this)
         val textColor = context.getProperTextColor()
         context.updateTextColors(binding.fingerprintLockHolder)
         binding.fingerprintImage.applyColorFilter(textColor)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Handler
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.widget.RelativeLayout
 import androidx.biometric.auth.AuthPromptHost
@@ -24,11 +23,13 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
     private var scrollView: MyScrollView? = null
     lateinit var hashListener: HashListener
 
-    private val binding = TabPatternBinding.inflate(LayoutInflater.from(context), this, false)
+    private lateinit var binding: TabPatternBinding
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = TabPatternBinding.bind(this)
+
         val textColor = context.getProperTextColor()
         context.updateTextColors(binding.patternLockHolder)
 
@@ -75,12 +76,14 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
                 binding.patternLockView.clearPattern()
                 binding.patternLockTitle.setText(R.string.repeat_pattern)
             }
+
             hash == newHash -> {
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.CORRECT)
                 Handler().postDelayed({
                     hashListener.receivedHash(hash, PROTECTION_PATTERN)
                 }, 300)
             }
+
             else -> {
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.WRONG)
                 context.toast(R.string.wrong_pattern)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
@@ -21,10 +21,12 @@ class PinTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, at
     private var pin = ""
     lateinit var hashListener: HashListener
 
-    private val binding = TabPinBinding.inflate(LayoutInflater.from(context), this, false)
+    private lateinit var binding: TabPinBinding
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = TabPinBinding.bind(this)
+
         context.updateTextColors(binding.pinLockHolder)
 
         binding.pin0.setOnClickListener { addNumber("0") }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenamePatternTab.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.provider.MediaStore
 import android.text.format.DateFormat
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.widget.RelativeLayout
 import androidx.exifinterface.media.ExifInterface
 import com.simplemobiletools.commons.R
@@ -18,8 +17,8 @@ import com.simplemobiletools.commons.models.Android30RenameFormat
 import com.simplemobiletools.commons.models.FileDirItem
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.*
-import kotlin.collections.ArrayList
+import java.util.Calendar
+import java.util.Locale
 
 class RenamePatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs), RenameTab {
     var ignoreClicks = false
@@ -29,10 +28,11 @@ class RenamePatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(c
     var activity: BaseSimpleActivity? = null
     var paths = ArrayList<String>()
 
-    private val binding = DialogRenameItemsPatternBinding.inflate(LayoutInflater.from(context), this, false)
+    private lateinit var binding: DialogRenameItemsPatternBinding
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = DialogRenameItemsPatternBinding.bind(this)
         context.updateTextColors(binding.renameItemsHolder)
     }
 
@@ -214,12 +214,14 @@ class RenamePatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(c
                                     activity.scanPathsRecursively(arrayListOf(newPath))
                                 }
                             }
+
                             Android30RenameFormat.CONTENT_RESOLVER -> {
                                 val values = ContentValues().apply {
                                     put(MediaStore.Images.Media.DISPLAY_NAME, newFileName)
                                 }
                                 context.contentResolver.update(uri, values, null, null)
                             }
+
                             Android30RenameFormat.NONE -> {
                                 activity.runOnUiThread {
                                     callback(true)

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/RenameSimpleTab.kt
@@ -4,7 +4,6 @@ import android.content.ContentValues
 import android.content.Context
 import android.provider.MediaStore
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.widget.RelativeLayout
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
@@ -21,10 +20,11 @@ class RenameSimpleTab(context: Context, attrs: AttributeSet) : RelativeLayout(co
     var activity: BaseSimpleActivity? = null
     var paths = ArrayList<String>()
 
-    private val binding = TabRenameSimpleBinding.inflate(LayoutInflater.from(context), this, true)
+    private lateinit var binding: TabRenameSimpleBinding
 
     override fun onFinishInflate() {
         super.onFinishInflate()
+        binding = TabRenameSimpleBinding.bind(this)
         context.updateTextColors(binding.renameSimpleHolder)
     }
 
@@ -168,12 +168,14 @@ class RenameSimpleTab(context: Context, attrs: AttributeSet) : RelativeLayout(co
                                     activity.scanPathsRecursively(arrayListOf(newPath))
                                 }
                             }
+
                             Android30RenameFormat.CONTENT_RESOLVER -> {
                                 val values = ContentValues().apply {
                                     put(MediaStore.Images.Media.DISPLAY_NAME, newName)
                                 }
                                 context.contentResolver.update(uri, values, null, null)
                             }
+
                             Android30RenameFormat.NONE -> {
                                 activity.runOnUiThread {
                                     callback(true)

--- a/commons/src/main/res/layout/dialog_rename.xml
+++ b/commons/src/main/res/layout/dialog_rename.xml
@@ -15,13 +15,11 @@
             android:layout_height="wrap_content">
 
             <com.google.android.material.tabs.TabItem
-                android:id="@+id/dialog_tab_simple"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/simple_renaming" />
 
             <com.google.android.material.tabs.TabItem
-                android:id="@+id/dialog_tab_pattern"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/pattern_renaming" />

--- a/commons/src/main/res/layout/dialog_security.xml
+++ b/commons/src/main/res/layout/dialog_security.xml
@@ -15,13 +15,11 @@
             android:layout_height="wrap_content">
 
             <com.google.android.material.tabs.TabItem
-                android:id="@+id/dialog_tab_pattern"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/pattern" />
 
             <com.google.android.material.tabs.TabItem
-                android:id="@+id/dialog_tab_pin"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/pin" />

--- a/samples/src/main/kotlin/com/simplemobiletools/commons/samples/activities/MainActivity.kt
+++ b/samples/src/main/kotlin/com/simplemobiletools/commons/samples/activities/MainActivity.kt
@@ -1,16 +1,11 @@
 package com.simplemobiletools.commons.samples.activities
 
-import android.content.Intent
 import android.os.Bundle
-import com.simplemobiletools.commons.activities.AboutActivity
 import com.simplemobiletools.commons.activities.BaseSimpleActivity
-import com.simplemobiletools.commons.activities.CustomizationActivity
 import com.simplemobiletools.commons.dialogs.BottomSheetChooserDialog
 import com.simplemobiletools.commons.extensions.appLaunched
 import com.simplemobiletools.commons.extensions.toast
 import com.simplemobiletools.commons.extensions.viewBinding
-import com.simplemobiletools.commons.helpers.APP_ICON_IDS
-import com.simplemobiletools.commons.helpers.APP_LAUNCHER_NAME
 import com.simplemobiletools.commons.helpers.LICENSE_AUTOFITTEXTVIEW
 import com.simplemobiletools.commons.models.FAQItem
 import com.simplemobiletools.commons.models.SimpleListItem


### PR DESCRIPTION
ViewBinding crashes when TabLayout items have IDs, because these are not real views - they are just dummy views used to define tabs in XML.
More info: https://stackoverflow.com/questions/66320075/missing-required-view-with-id-with-view-binding-and-navigation-component/66325932#66325932

After that Tabs caused endless loop, because they were inflating themselves using `...Binding.inflate`. Since they are their own views which also use XML, `...Binging.bind` should be used in `onFinishInflate`.