### PR TITLE
add gson proguard rules

### DIFF
--- a/commons/proguard-rules.pro
+++ b/commons/proguard-rules.pro
@@ -26,3 +26,44 @@
 }
 -dontwarn java.lang.invoke.StringConcatFactory
 -dontwarn javax.swing.tree.TreeNode
+
+#Gson https://github.com/google/gson/blob/main/gson/src/main/resources/META-INF/proguard/gson.pro
+-keepattributes Signature
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault
+
+-if class com.google.gson.reflect.TypeToken
+-keep,allowobfuscation class com.google.gson.reflect.TypeToken
+
+-keep,allowobfuscation class * extends com.google.gson.reflect.TypeToken
+-keep,allowobfuscation,allowoptimization @com.google.gson.annotations.JsonAdapter class *
+
+-keepclassmembers,allowobfuscation class * {
+  @com.google.gson.annotations.Expose <fields>;
+  @com.google.gson.annotations.JsonAdapter <fields>;
+  @com.google.gson.annotations.Since <fields>;
+  @com.google.gson.annotations.Until <fields>;
+}
+
+-keepclassmembers class * extends com.google.gson.TypeAdapter {
+  <init>();
+}
+-keepclassmembers class * implements com.google.gson.TypeAdapterFactory {
+  <init>();
+}
+-keepclassmembers class * implements com.google.gson.JsonSerializer {
+  <init>();
+}
+-keepclassmembers class * implements com.google.gson.JsonDeserializer {
+  <init>();
+}
+
+-if class *
+-keepclasseswithmembers,allowobfuscation class <1> {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+-if class * {
+  @com.google.gson.annotations.SerializedName <fields>;
+}
+-keepclassmembers,allowobfuscation,allowoptimization class <1> {
+  <init>();
+}


### PR DESCRIPTION
starting with `AGP 8+`, `R8` has started to work `fullMode=true` by default. 
which means more aggressive optimizations.
it now requires more proguard rules for `gson` library 