### PR TITLE
Revert "Make adapter activity variable overridable"

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewAdapter.kt
@@ -15,7 +15,7 @@ import com.simplemobiletools.commons.views.MyRecyclerView
 import kotlin.math.max
 import kotlin.math.min
 
-abstract class MyRecyclerViewAdapter(open val activity: BaseSimpleActivity, val recyclerView: MyRecyclerView, val itemClick: (Any) -> Unit) :
+abstract class MyRecyclerViewAdapter(val activity: BaseSimpleActivity, val recyclerView: MyRecyclerView, val itemClick: (Any) -> Unit) :
     RecyclerView.Adapter<MyRecyclerViewAdapter.ViewHolder>() {
     protected val baseConfig = activity.baseConfig
     protected val resources = activity.resources!!

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewListAdapter.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/adapters/MyRecyclerViewListAdapter.kt
@@ -20,7 +20,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 abstract class MyRecyclerViewListAdapter<T>(
-    open val activity: BaseSimpleActivity,
+    val activity: BaseSimpleActivity,
     val recyclerView: MyRecyclerView,
     diffUtil: DiffUtil.ItemCallback<T>,
     val itemClick: (T) -> Unit,


### PR DESCRIPTION
Reverts SimpleMobileTools/Simple-Commons#1810

It was useless, I didn't remember that one cannot override a property without making it null at init in the superclass, and `activity` is used at init for initializing other variables so it will throw an NPE. I'm reverting it so no one else causes a crash by overriding it accidentally.