### PR TITLE
Improve password protection

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Int.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/Int.kt
@@ -4,12 +4,17 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.media.ExifInterface
+import android.os.Handler
+import android.os.Looper
 import android.text.format.DateFormat
 import android.text.format.DateUtils
 import android.text.format.Time
+import androidx.core.os.postDelayed
 import com.simplemobiletools.commons.helpers.DARK_GREY
 import java.text.DecimalFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Locale
+import java.util.Random
 
 fun Int.getContrastColor(): Int {
     val y = (299 * Color.red(this) + 587 * Color.green(this) + 114 * Color.blue(this)) / 1000
@@ -185,11 +190,23 @@ fun Int.ensureTwoDigits(): String {
 }
 
 fun Int.getColorStateList(): ColorStateList {
-    val states = arrayOf(intArrayOf(android.R.attr.state_enabled),
+    val states = arrayOf(
+        intArrayOf(android.R.attr.state_enabled),
         intArrayOf(-android.R.attr.state_enabled),
         intArrayOf(-android.R.attr.state_checked),
         intArrayOf(android.R.attr.state_pressed)
     )
     val colors = intArrayOf(this, this, this, this)
     return ColorStateList(states, colors)
+}
+
+fun Int.countdown(intervalMillis: Long, callback: (count: Int) -> Unit) {
+    callback(this)
+    if (this == 0) {
+        return
+    }
+
+    Handler(Looper.getMainLooper()).postDelayed(intervalMillis) {
+        (this - 1).countdown(intervalMillis, callback)
+    }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/TextView.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/TextView.kt
@@ -4,8 +4,11 @@ import android.graphics.Paint
 import android.text.SpannableString
 import android.text.TextPaint
 import android.text.style.URLSpan
+import android.view.animation.AlphaAnimation
+import android.view.animation.Animation
 import android.widget.TextView
 import androidx.annotation.StringRes
+import androidx.core.widget.doOnTextChanged
 
 val TextView.value: String get() = text.toString().trim()
 
@@ -32,5 +35,16 @@ fun TextView.setTextOrBeGone(@StringRes textRes: Int?) {
         this.text = context.getString(textRes)
     } else {
         beGone()
+    }
+}
+
+fun TextView.blink(count: Int = 3, duration: Long = 150L): Animation {
+    return AlphaAnimation(0.0f, 1.0f).apply {
+        this.duration = duration
+        startOffset = 20
+        repeatMode = Animation.REVERSE
+        repeatCount = count
+        startAnimation(this)
+        doOnTextChanged { _, _, _, _ -> cancel() }
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
@@ -9,7 +9,9 @@ import com.simplemobiletools.commons.extensions.getInternalStoragePath
 import com.simplemobiletools.commons.extensions.getSDCardPath
 import com.simplemobiletools.commons.extensions.getSharedPrefs
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.LinkedList
+import java.util.Locale
 
 open class BaseConfig(val context: Context) {
     protected val prefs = context.getSharedPrefs()
@@ -584,4 +586,12 @@ open class BaseConfig(val context: Context) {
     var lastAutoBackupTime: Long
         get() = prefs.getLong(LAST_AUTO_BACKUP_TIME, 0L)
         set(lastAutoBackupTime) = prefs.edit().putLong(LAST_AUTO_BACKUP_TIME, lastAutoBackupTime).apply()
+
+    var passwordRetryCount: Int
+        get() = prefs.getInt(PASSWORD_RETRY_COUNT, 0)
+        set(passwordRetryCount) = prefs.edit().putInt(PASSWORD_RETRY_COUNT, passwordRetryCount).apply()
+
+    var passwordCountdownStartMs: Long
+        get() = prefs.getLong(PASSWORD_COUNTDOWN_START_MS, 0L)
+        set(passwordCountdownStartMs) = prefs.edit().putLong(PASSWORD_COUNTDOWN_START_MS, passwordCountdownStartMs).apply()
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -192,6 +192,11 @@ const val AUTO_BACKUP = "auto_backup"
 const val AUTO_BACKUP_FOLDER = "auto_backup_folder"
 const val AUTO_BACKUP_FILENAME = "auto_backup_filename"
 const val LAST_AUTO_BACKUP_TIME = "last_auto_backup_time"
+const val PASSWORD_RETRY_COUNT = "password_retry_count"
+const val PASSWORD_COUNTDOWN_START_MS = "password_count_down_start_ms"
+
+const val MAX_PASSWORD_RETRY_COUNT = 3
+const val DEFAULT_PASSWORD_COUNTDOWN = 5
 
 // contact grid view constants
 const val CONTACTS_GRID_MAX_COLUMNS_COUNT = 10

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/Constants.kt
@@ -197,6 +197,7 @@ const val PASSWORD_COUNTDOWN_START_MS = "password_count_down_start_ms"
 
 const val MAX_PASSWORD_RETRY_COUNT = 3
 const val DEFAULT_PASSWORD_COUNTDOWN = 5
+const val MINIMUM_PIN_LENGTH = 4
 
 // contact grid view constants
 const val CONTACTS_GRID_MAX_COLUMNS_COUNT = 10

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
@@ -1,0 +1,123 @@
+package com.simplemobiletools.commons.interfaces
+
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.AttributeSet
+import android.widget.RelativeLayout
+import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.core.os.postDelayed
+import com.simplemobiletools.commons.R
+import com.simplemobiletools.commons.extensions.baseConfig
+import com.simplemobiletools.commons.extensions.blink
+import com.simplemobiletools.commons.extensions.countdown
+import com.simplemobiletools.commons.extensions.getProperTextColor
+import com.simplemobiletools.commons.helpers.DEFAULT_PASSWORD_COUNTDOWN
+import com.simplemobiletools.commons.helpers.MAX_PASSWORD_RETRY_COUNT
+
+abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs), SecurityTab {
+
+    abstract val protectionType: Int
+    abstract val defaultTextRes: Int
+    abstract val wrongTextRes: Int
+    abstract val titleTextView: TextView
+
+    lateinit var computedHash: String
+    lateinit var requiredHash: String
+    lateinit var hashListener: HashListener
+
+    private val config = context.baseConfig
+    private val handler = Handler(Looper.getMainLooper())
+
+    fun isLockedOut() = requiredHash.isNotEmpty() && getCountdown() > 0
+
+    fun onCorrectPassword() {
+        resetCountdown()
+        handler.postDelayed(delayInMillis = 300) {
+            hashListener.receivedHash(computedHash, protectionType)
+        }
+    }
+
+    fun onIncorrectPassword() {
+        config.passwordRetryCount += 1
+        if (requiredHash.isNotEmpty() && shouldStartCountdown()) {
+            startCountdown()
+        } else {
+            updateTitle(context.getString(wrongTextRes), context.getColor(R.color.md_red))
+            titleTextView.blink()
+            handler.postDelayed(1000) {
+                updateTitle(context.getString(defaultTextRes), context.getProperTextColor())
+            }
+        }
+    }
+
+    fun maybeShowCountdown() {
+        if (shouldStartCountdown()) {
+            startCountdown()
+        } else {
+            updateCountdown(0)
+        }
+    }
+
+    private fun shouldStartCountdown() = config.passwordRetryCount >= MAX_PASSWORD_RETRY_COUNT
+
+    private fun resetCountdown() {
+        config.passwordRetryCount = 0
+        config.passwordCountdownStartMs = 0
+    }
+
+    private fun getCountdown(): Int {
+        val retryCount = config.passwordRetryCount
+        if (retryCount >= MAX_PASSWORD_RETRY_COUNT) {
+            val currentTimeMs = System.currentTimeMillis()
+            val countdownStartMs = config.passwordCountdownStartMs
+
+            if (countdownStartMs == 0L) {
+                config.passwordCountdownStartMs = currentTimeMs
+                return DEFAULT_PASSWORD_COUNTDOWN
+            }
+
+            val countdownWaitMs = DEFAULT_PASSWORD_COUNTDOWN * 1000L
+            val elapsedMs = currentTimeMs - countdownStartMs
+
+            return if (elapsedMs < countdownWaitMs) {
+                val remainingMs = countdownWaitMs - elapsedMs
+                val remainingSeconds = remainingMs / 1000L
+                remainingSeconds.toInt()
+            } else {
+                0
+            }
+        }
+
+        return 0
+    }
+
+    private fun startCountdown() {
+        getCountdown().countdown(intervalMillis = 1000L) { count ->
+            updateCountdown(count)
+            if (count == 0) {
+                resetCountdown()
+            }
+        }
+    }
+
+    private fun updateCountdown(count: Int) {
+        removeCallbacks()
+        if (count > 0) {
+            updateTitle(context.getString(R.string.too_many_incorrect_attempts, count), context.getColor(R.color.md_red))
+        } else {
+            updateTitle(context.getString(defaultTextRes), context.getProperTextColor())
+        }
+    }
+
+    private fun removeCallbacks() = handler.removeCallbacksAndMessages(null)
+
+    private fun updateTitle(text: String, @ColorInt color: Int) {
+        titleTextView.text = text
+        titleTextView.setTextColor(color)
+    }
+
+    override fun visibilityChanged(isVisible: Boolean) {}
+}
+

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
@@ -46,7 +46,7 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
         } else {
             updateTitle(context.getString(wrongTextRes), context.getColor(R.color.md_red))
             titleTextView.blink()
-            handler.postDelayed(1000) {
+            handler.postDelayed(delayInMillis = 1000) {
                 updateTitle(context.getString(defaultTextRes), context.getProperTextColor())
             }
         }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Handler
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.widget.RelativeLayout
+import android.widget.TextView
 import androidx.biometric.auth.AuthPromptHost
 import com.andrognito.patternlockview.PatternLockView
 import com.andrognito.patternlockview.listener.PatternLockViewListener
@@ -14,16 +14,19 @@ import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.databinding.TabPatternBinding
 import com.simplemobiletools.commons.extensions.*
 import com.simplemobiletools.commons.helpers.PROTECTION_PATTERN
+import com.simplemobiletools.commons.interfaces.BaseSecurityTab
 import com.simplemobiletools.commons.interfaces.HashListener
-import com.simplemobiletools.commons.interfaces.SecurityTab
 
-class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context, attrs), SecurityTab {
-    private var hash = ""
-    private var requiredHash = ""
+class PatternTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(context, attrs) {
     private var scrollView: MyScrollView? = null
-    lateinit var hashListener: HashListener
 
     private lateinit var binding: TabPatternBinding
+
+    override val protectionType = PROTECTION_PATTERN
+    override val defaultTextRes = R.string.insert_pattern
+    override val wrongTextRes = R.string.wrong_pattern
+    override val titleTextView: TextView
+        get() = binding.patternLockTitle
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onFinishInflate() {
@@ -33,7 +36,7 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
         val textColor = context.getProperTextColor()
         context.updateTextColors(binding.patternLockHolder)
 
-        binding.patternLockView.setOnTouchListener { v, event ->
+        binding.patternLockView.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> scrollView?.isScrollable = false
                 MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> scrollView?.isScrollable = true
@@ -54,6 +57,9 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
 
             override fun onProgress(progressPattern: MutableList<PatternLockView.Dot>?) {}
         })
+
+        binding.patternLockIcon.applyColorFilter(textColor)
+        maybeShowCountdown()
     }
 
     override fun initTab(
@@ -65,38 +71,38 @@ class PatternTab(context: Context, attrs: AttributeSet) : RelativeLayout(context
     ) {
         this.requiredHash = requiredHash
         this.scrollView = scrollView
-        hash = requiredHash
+        computedHash = requiredHash
         hashListener = listener
     }
 
     private fun receivedHash(newHash: String) {
+        if (isLockedOut()) {
+            performHapticFeedback()
+            return
+        }
+
         when {
-            hash.isEmpty() -> {
-                hash = newHash
+            computedHash.isEmpty() -> {
+                computedHash = newHash
                 binding.patternLockView.clearPattern()
                 binding.patternLockTitle.setText(R.string.repeat_pattern)
             }
 
-            hash == newHash -> {
+            computedHash == newHash -> {
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.CORRECT)
-                Handler().postDelayed({
-                    hashListener.receivedHash(hash, PROTECTION_PATTERN)
-                }, 300)
+                onCorrectPassword()
             }
 
             else -> {
+                onIncorrectPassword()
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.WRONG)
-                context.toast(R.string.wrong_pattern)
                 Handler().postDelayed({
                     binding.patternLockView.clearPattern()
                     if (requiredHash.isEmpty()) {
-                        hash = ""
-                        binding.patternLockTitle.setText(R.string.insert_pattern)
+                        computedHash = ""
                     }
                 }, 1000)
             }
         }
     }
-
-    override fun visibilityChanged(isVisible: Boolean) {}
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
@@ -7,6 +7,7 @@ import android.util.AttributeSet
 import android.view.MotionEvent
 import android.widget.TextView
 import androidx.biometric.auth.AuthPromptHost
+import androidx.core.os.postDelayed
 import com.andrognito.patternlockview.PatternLockView
 import com.andrognito.patternlockview.listener.PatternLockViewListener
 import com.andrognito.patternlockview.utils.PatternLockUtils
@@ -96,12 +97,12 @@ class PatternTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(contex
             else -> {
                 onIncorrectPassword()
                 binding.patternLockView.setViewMode(PatternLockView.PatternViewMode.WRONG)
-                Handler().postDelayed({
+                Handler().postDelayed(delayInMillis = 1000) {
                     binding.patternLockView.clearPattern()
                     if (requiredHash.isEmpty()) {
                         computedHash = ""
                     }
-                }, 1000)
+                }
             }
         }
     }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
@@ -7,6 +7,7 @@ import androidx.biometric.auth.AuthPromptHost
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.databinding.TabPinBinding
 import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.helpers.MINIMUM_PIN_LENGTH
 import com.simplemobiletools.commons.helpers.PROTECTION_PIN
 import com.simplemobiletools.commons.interfaces.BaseSecurityTab
 import com.simplemobiletools.commons.interfaces.HashListener
@@ -86,6 +87,11 @@ class PinTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(context, a
             when {
                 pin.isEmpty() -> {
                     context.toast(R.string.please_enter_pin)
+                }
+
+                computedHash.isEmpty() && pin.length < MINIMUM_PIN_LENGTH -> {
+                    resetPin()
+                    context.toast(R.string.pin_must_be_4_digits_long)
                 }
 
                 computedHash.isEmpty() -> {

--- a/commons/src/main/res/drawable/ic_lock_outlined_vector.xml
+++ b/commons/src/main/res/drawable/ic_lock_outlined_vector.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM9,6c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2L9,8L9,6zM18,20L6,20L6,10h12v10zM12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2z" />
+</vector>

--- a/commons/src/main/res/drawable/ic_lock_outlined_vector.xml
+++ b/commons/src/main/res/drawable/ic_lock_outlined_vector.xml
@@ -1,9 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="@android:color/white"
-        android:pathData="M18,8h-1L17,6c0,-2.76 -2.24,-5 -5,-5S7,3.24 7,6v2L6,8c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2L20,10c0,-1.1 -0.9,-2 -2,-2zM9,6c0,-1.66 1.34,-3 3,-3s3,1.34 3,3v2L9,8L9,6zM18,20L6,20L6,10h12v10zM12,17c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2z" />
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="@android:color/white" android:pathData="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 0.9-2 2v10c0 1.1 0.9 2 2 2h12c1.1 0 2-0.9 2-2V10c0-1.1-0.9-2-2-2zM9 6c0-1.66 1.34-3 3-3s3 1.34 3 3v2H9V6zm9 14H6V10h12v10zm-6-3c1.1 0 2-0.9 2-2s-0.9-2-2-2-2 0.9-2 2 0.9 2 2 2z"/>
 </vector>

--- a/commons/src/main/res/layout/tab_pattern.xml
+++ b/commons/src/main/res/layout/tab_pattern.xml
@@ -1,22 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.simplemobiletools.commons.views.PatternTab
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.simplemobiletools.commons.views.PatternTab xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/pattern_lock_holder"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/pattern_lock_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/normal_margin"
+        android:src="@drawable/ic_lock_outlined_vector" />
 
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/pattern_lock_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_below="@id/pattern_lock_icon"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
         android:padding="@dimen/activity_margin"
-        android:text="@string/insert_pattern"/>
+        android:text="@string/insert_pattern"
+        android:textAlignment="center" />
 
     <com.andrognito.patternlockview.PatternLockView
         android:id="@+id/pattern_lock_view"
         android:layout_width="280dp"
         android:layout_height="280dp"
         android:layout_below="@+id/pattern_lock_title"
-        android:layout_centerInParent="true"/>
+        android:layout_centerInParent="true" />
 
 </com.simplemobiletools.commons.views.PatternTab>

--- a/commons/src/main/res/layout/tab_pin.xml
+++ b/commons/src/main/res/layout/tab_pin.xml
@@ -1,19 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.simplemobiletools.commons.views.PinTab
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.simplemobiletools.commons.views.PinTab xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/pin_lock_holder"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
+
+    <androidx.appcompat.widget.AppCompatImageView
+        android:id="@+id/pin_lock_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="@dimen/activity_margin"
+        android:src="@drawable/ic_lock_outlined_vector" />
 
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/pin_lock_title"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/small_margin"
+        android:layout_below="@id/pin_lock_icon"
+        android:layout_alignParentStart="true"
+        android:layout_alignParentEnd="true"
+        android:minLines="2"
         android:paddingLeft="@dimen/activity_margin"
-        android:paddingRight="@dimen/activity_margin"
         android:paddingTop="@dimen/activity_margin"
-        android:text="@string/enter_pin"/>
+        android:paddingRight="@dimen/activity_margin"
+        android:paddingBottom="@dimen/small_margin"
+        android:text="@string/enter_pin"
+        android:textAlignment="center" />
 
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/pin_lock_current_pin"
@@ -24,9 +37,10 @@
         android:letterSpacing="1.05"
         android:lines="1"
         android:maxLength="10"
-        android:paddingBottom="@dimen/small_margin"
         android:paddingTop="@dimen/small_margin"
-        android:textSize="@dimen/big_text_size"/>
+        android:paddingBottom="@dimen/small_margin"
+        android:textSize="@dimen/big_text_size"
+        tools:text="****" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -47,7 +61,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="1"/>
+                android:text="1" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_2"
@@ -55,7 +69,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="2"/>
+                android:text="2" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_3"
@@ -63,7 +77,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="3"/>
+                android:text="3" />
         </LinearLayout>
 
         <LinearLayout
@@ -78,7 +92,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="4"/>
+                android:text="4" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_5"
@@ -86,7 +100,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="5"/>
+                android:text="5" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_6"
@@ -94,7 +108,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="6"/>
+                android:text="6" />
         </LinearLayout>
 
         <LinearLayout
@@ -109,7 +123,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="7"/>
+                android:text="7" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_8"
@@ -117,7 +131,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="8"/>
+                android:text="8" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_9"
@@ -125,7 +139,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="9"/>
+                android:text="9" />
         </LinearLayout>
 
         <LinearLayout
@@ -140,7 +154,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="C"/>
+                android:text="C" />
 
             <com.simplemobiletools.commons.views.MyTextView
                 android:id="@+id/pin_0"
@@ -148,7 +162,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
-                android:text="0"/>
+                android:text="0" />
 
             <ImageView
                 android:id="@+id/pin_ok"
@@ -157,7 +171,7 @@
                 android:layout_height="match_parent"
                 android:layout_weight="1"
                 android:padding="@dimen/activity_margin"
-                android:src="@drawable/ic_check_vector"/>
+                android:src="@drawable/ic_check_vector" />
 
         </LinearLayout>
     </LinearLayout>

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">ادخل رمز الـ PIN</string>
     <string name="please_enter_pin">يرجى إدخال رمز الـ PIN</string>
     <string name="wrong_pin">رمز الـ PIN غير صحيح</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">تكرار رمز الـ PIN</string>
     <string name="pattern">النمط</string>
     <string name="insert_pattern">إدراج النمط</string>

--- a/commons/src/main/res/values-ar/strings.xml
+++ b/commons/src/main/res/values-ar/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">ادخل رمز الـ PIN</string>
     <string name="please_enter_pin">يرجى إدخال رمز الـ PIN</string>
     <string name="wrong_pin">رمز الـ PIN غير صحيح</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">تكرار رمز الـ PIN</string>
     <string name="pattern">النمط</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">PIN\'i daxil edin</string>
     <string name="please_enter_pin">Xahiş olunur PIN\'i daxil edin</string>
     <string name="wrong_pin">PIN yanlışdır</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN\'i təkrarlayın</string>
     <string name="pattern">Model</string>
     <string name="insert_pattern">Model daxil edin</string>

--- a/commons/src/main/res/values-az/strings.xml
+++ b/commons/src/main/res/values-az/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">PIN\'i daxil edin</string>
     <string name="please_enter_pin">Xahiş olunur PIN\'i daxil edin</string>
     <string name="wrong_pin">PIN yanlışdır</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN\'i təkrarlayın</string>
     <string name="pattern">Model</string>

--- a/commons/src/main/res/values-be/strings.xml
+++ b/commons/src/main/res/values-be/strings.xml
@@ -473,6 +473,7 @@
     <string name="enter_pin">Увядзіце PIN-код</string>
     <string name="please_enter_pin">Увядзіце PIN-код</string>
     <string name="wrong_pin">Няправільны PIN-код</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Паўтарыце PIN-код</string>
     <string name="pattern">Графічны ключ</string>

--- a/commons/src/main/res/values-be/strings.xml
+++ b/commons/src/main/res/values-be/strings.xml
@@ -473,6 +473,7 @@
     <string name="enter_pin">Увядзіце PIN-код</string>
     <string name="please_enter_pin">Увядзіце PIN-код</string>
     <string name="wrong_pin">Няправільны PIN-код</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Паўтарыце PIN-код</string>
     <string name="pattern">Графічны ключ</string>
     <string name="insert_pattern">Намалюйце графічны ключ</string>

--- a/commons/src/main/res/values-bg/strings.xml
+++ b/commons/src/main/res/values-bg/strings.xml
@@ -465,6 +465,7 @@
     <string name="enter_pin">Въведи ПИН</string>
     <string name="please_enter_pin">Моля, въведете ПИН</string>
     <string name="wrong_pin">Грешен ПИН</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повтори ПИН</string>
     <string name="pattern">Шаблон</string>

--- a/commons/src/main/res/values-bg/strings.xml
+++ b/commons/src/main/res/values-bg/strings.xml
@@ -465,6 +465,7 @@
     <string name="enter_pin">Въведи ПИН</string>
     <string name="please_enter_pin">Моля, въведете ПИН</string>
     <string name="wrong_pin">Грешен ПИН</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повтори ПИН</string>
     <string name="pattern">Шаблон</string>
     <string name="insert_pattern">Въведи шаблон</string>

--- a/commons/src/main/res/values-bn/strings.xml
+++ b/commons/src/main/res/values-bn/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-bn/strings.xml
+++ b/commons/src/main/res/values-bn/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -488,6 +488,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-br/strings.xml
+++ b/commons/src/main/res/values-br/strings.xml
@@ -488,6 +488,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Introduïu el PIN</string>
     <string name="please_enter_pin">Introduïu un PIN</string>
     <string name="wrong_pin">PIN incorrecte</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetiu el PIN</string>
     <string name="pattern">Patró</string>

--- a/commons/src/main/res/values-ca/strings.xml
+++ b/commons/src/main/res/values-ca/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Introduïu el PIN</string>
     <string name="please_enter_pin">Introduïu un PIN</string>
     <string name="wrong_pin">PIN incorrecte</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetiu el PIN</string>
     <string name="pattern">Patró</string>
     <string name="insert_pattern">Introduïu el patró</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -472,6 +472,7 @@
     <string name="enter_pin">Zadejte PIN</string>
     <string name="please_enter_pin">Prosím, zadejte PIN</string>
     <string name="wrong_pin">Nesprávný PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Opakujte PIN</string>
     <string name="pattern">Vzor</string>
     <string name="insert_pattern">Zadejte vzor</string>

--- a/commons/src/main/res/values-cs/strings.xml
+++ b/commons/src/main/res/values-cs/strings.xml
@@ -472,6 +472,7 @@
     <string name="enter_pin">Zadejte PIN</string>
     <string name="please_enter_pin">Prosím, zadejte PIN</string>
     <string name="wrong_pin">Nesprávný PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Opakujte PIN</string>
     <string name="pattern">Vzor</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -491,6 +491,7 @@
     <string name="enter_pin">Rho PIN</string>
     <string name="please_enter_pin">Rho PIN, plîs.</string>
     <string name="wrong_pin">PIN anghywir</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Rho\'r PIN eto</string>
     <string name="pattern">Patrwm</string>
     <string name="insert_pattern">Rho batrwm</string>

--- a/commons/src/main/res/values-cy/strings.xml
+++ b/commons/src/main/res/values-cy/strings.xml
@@ -491,6 +491,7 @@
     <string name="enter_pin">Rho PIN</string>
     <string name="please_enter_pin">Rho PIN, plîs.</string>
     <string name="wrong_pin">PIN anghywir</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Rho\'r PIN eto</string>
     <string name="pattern">Patrwm</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Indtast PIN</string>
     <string name="please_enter_pin">Indtast en PIN</string>
     <string name="wrong_pin">Forkert PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Gentag PIN</string>
     <string name="pattern">Mønster</string>
     <string name="insert_pattern">Indsæt mønster</string>

--- a/commons/src/main/res/values-da/strings.xml
+++ b/commons/src/main/res/values-da/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Indtast PIN</string>
     <string name="please_enter_pin">Indtast en PIN</string>
     <string name="wrong_pin">Forkert PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Gentag PIN</string>
     <string name="pattern">Mønster</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">PIN eingeben</string>
     <string name="please_enter_pin">Bitte eine PIN eingeben</string>
     <string name="wrong_pin">Falsche PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN wiederholen</string>
     <string name="pattern">Muster</string>

--- a/commons/src/main/res/values-de/strings.xml
+++ b/commons/src/main/res/values-de/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">PIN eingeben</string>
     <string name="please_enter_pin">Bitte eine PIN eingeben</string>
     <string name="wrong_pin">Falsche PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN wiederholen</string>
     <string name="pattern">Muster</string>
     <string name="insert_pattern">Muster zeichnen</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -464,6 +464,7 @@
     <string name="enter_pin">Εισαγωγή PIN</string>
     <string name="please_enter_pin">Παρακαλώ εισάγετε ένα PIN</string>
     <string name="wrong_pin">Λάθος PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Επανάληψη PIN</string>
     <string name="pattern">Μοτίβο</string>
     <string name="insert_pattern">Εισαγωγή μοτίβου</string>

--- a/commons/src/main/res/values-el/strings.xml
+++ b/commons/src/main/res/values-el/strings.xml
@@ -464,6 +464,7 @@
     <string name="enter_pin">Εισαγωγή PIN</string>
     <string name="please_enter_pin">Παρακαλώ εισάγετε ένα PIN</string>
     <string name="wrong_pin">Λάθος PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Επανάληψη PIN</string>
     <string name="pattern">Μοτίβο</string>

--- a/commons/src/main/res/values-eo/strings.xml
+++ b/commons/src/main/res/values-eo/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-eo/strings.xml
+++ b/commons/src/main/res/values-eo/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Introduzca PIN</string>
     <string name="please_enter_pin">Por favor introduzca PIN</string>
     <string name="wrong_pin">PIN erróneo</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Patrón</string>
     <string name="insert_pattern">Inserte Patrón</string>

--- a/commons/src/main/res/values-es/strings.xml
+++ b/commons/src/main/res/values-es/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Introduzca PIN</string>
     <string name="please_enter_pin">Por favor introduzca PIN</string>
     <string name="wrong_pin">PIN erróneo</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Patrón</string>

--- a/commons/src/main/res/values-et/strings.xml
+++ b/commons/src/main/res/values-et/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Sisesta PIN</string>
     <string name="please_enter_pin">Palun sisesta PIN-kood</string>
     <string name="wrong_pin">Vale PIN-kood</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Korda PIN-koodi</string>
     <string name="pattern">Muster</string>

--- a/commons/src/main/res/values-et/strings.xml
+++ b/commons/src/main/res/values-et/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Sisesta PIN</string>
     <string name="please_enter_pin">Palun sisesta PIN-kood</string>
     <string name="wrong_pin">Vale PIN-kood</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Korda PIN-koodi</string>
     <string name="pattern">Muster</string>
     <string name="insert_pattern">Joonista muster</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Sartu PINa</string>
     <string name="please_enter_pin">Sartu PINa</string>
     <string name="wrong_pin">Okerreko PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Errpeikatu PIN</string>
     <string name="pattern">Eredua</string>
     <string name="insert_pattern">Sartu eredua</string>

--- a/commons/src/main/res/values-eu/strings.xml
+++ b/commons/src/main/res/values-eu/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Sartu PINa</string>
     <string name="please_enter_pin">Sartu PINa</string>
     <string name="wrong_pin">Okerreko PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Errpeikatu PIN</string>
     <string name="pattern">Eredua</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">پین را وارد کنید</string>
     <string name="please_enter_pin">لطفا یک پین وارد کنید</string>
     <string name="wrong_pin">پین اشتباه است</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">پین را تکرار کنید</string>
     <string name="pattern">الگو</string>
     <string name="insert_pattern">الگو را وارد کنید</string>

--- a/commons/src/main/res/values-fa/strings.xml
+++ b/commons/src/main/res/values-fa/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">پین را وارد کنید</string>
     <string name="please_enter_pin">لطفا یک پین وارد کنید</string>
     <string name="wrong_pin">پین اشتباه است</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">پین را تکرار کنید</string>
     <string name="pattern">الگو</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Syötä PIN</string>
     <string name="please_enter_pin">Syötä PIN</string>
     <string name="wrong_pin">Väärä PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Toista PIN</string>
     <string name="pattern">Kuvio</string>
     <string name="insert_pattern">Syötä kuvio</string>

--- a/commons/src/main/res/values-fi/strings.xml
+++ b/commons/src/main/res/values-fi/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Syötä PIN</string>
     <string name="please_enter_pin">Syötä PIN</string>
     <string name="wrong_pin">Väärä PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Toista PIN</string>
     <string name="pattern">Kuvio</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Saisir un code PIN</string>
     <string name="please_enter_pin">Veuillez saisir un code PIN</string>
     <string name="wrong_pin">Code PIN incorrect</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Saisissez à nouveau le code PIN</string>
     <string name="pattern">Schéma</string>
     <string name="insert_pattern">Dessiner un schéma</string>

--- a/commons/src/main/res/values-fr/strings.xml
+++ b/commons/src/main/res/values-fr/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Saisir un code PIN</string>
     <string name="please_enter_pin">Veuillez saisir un code PIN</string>
     <string name="wrong_pin">Code PIN incorrect</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Saisissez à nouveau le code PIN</string>
     <string name="pattern">Schéma</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -465,6 +465,7 @@
     <string name="enter_pin">Introduce PIN</string>
     <string name="please_enter_pin">Por favor, introduce un PIN</string>
     <string name="wrong_pin">PIN erróneo</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Patrón</string>
     <string name="insert_pattern">Insire patrón</string>

--- a/commons/src/main/res/values-gl/strings.xml
+++ b/commons/src/main/res/values-gl/strings.xml
@@ -465,6 +465,7 @@
     <string name="enter_pin">Introduce PIN</string>
     <string name="please_enter_pin">Por favor, introduce un PIN</string>
     <string name="wrong_pin">PIN erróneo</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Patrón</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-hi-rIN/strings.xml
+++ b/commons/src/main/res/values-hi-rIN/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -477,6 +477,7 @@
     <string name="enter_pin">Unesite PIN</string>
     <string name="please_enter_pin">Molimo unesite PIN</string>
     <string name="wrong_pin">Pogrešan PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ponovite PIN</string>
     <string name="pattern">Uzorak</string>
     <string name="insert_pattern">Unesite uzorak</string>

--- a/commons/src/main/res/values-hr/strings.xml
+++ b/commons/src/main/res/values-hr/strings.xml
@@ -477,6 +477,7 @@
     <string name="enter_pin">Unesite PIN</string>
     <string name="please_enter_pin">Molimo unesite PIN</string>
     <string name="wrong_pin">Pogrešan PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ponovite PIN</string>
     <string name="pattern">Uzorak</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Írja be a PIN-kódot</string>
     <string name="please_enter_pin">Írjon be egy PIN-kódot</string>
     <string name="wrong_pin">Hibás PIN-kód</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN-kód újra</string>
     <string name="pattern">Minta</string>
     <string name="insert_pattern">Minta megadása</string>

--- a/commons/src/main/res/values-hu/strings.xml
+++ b/commons/src/main/res/values-hu/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Írja be a PIN-kódot</string>
     <string name="please_enter_pin">Írjon be egy PIN-kódot</string>
     <string name="wrong_pin">Hibás PIN-kód</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN-kód újra</string>
     <string name="pattern">Minta</string>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -455,6 +455,7 @@
     <string name="enter_pin">Masukkan PIN</string>
     <string name="please_enter_pin">Silakan masukkan PIN</string>
     <string name="wrong_pin">PIN salah</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ulangi PIN</string>
     <string name="pattern">Pola</string>
     <string name="insert_pattern">Masukkan pola</string>

--- a/commons/src/main/res/values-in/strings.xml
+++ b/commons/src/main/res/values-in/strings.xml
@@ -455,6 +455,7 @@
     <string name="enter_pin">Masukkan PIN</string>
     <string name="please_enter_pin">Silakan masukkan PIN</string>
     <string name="wrong_pin">PIN salah</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ulangi PIN</string>
     <string name="pattern">Pola</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Inserisci un PIN</string>
     <string name="please_enter_pin">Per favore inserisci un PIN</string>
     <string name="wrong_pin">PIN errato</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ripeti il PIN</string>
     <string name="pattern">Sequenza</string>
     <string name="insert_pattern">Inserisci una sequenza</string>

--- a/commons/src/main/res/values-it/strings.xml
+++ b/commons/src/main/res/values-it/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Inserisci un PIN</string>
     <string name="please_enter_pin">Per favore inserisci un PIN</string>
     <string name="wrong_pin">PIN errato</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ripeti il PIN</string>
     <string name="pattern">Sequenza</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">הכנס PIN</string>
     <string name="please_enter_pin">נא להכניס PIN</string>
     <string name="wrong_pin">שגיאה ב PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">חזור על PIN</string>
     <string name="pattern">דפוס</string>

--- a/commons/src/main/res/values-iw/strings.xml
+++ b/commons/src/main/res/values-iw/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">הכנס PIN</string>
     <string name="please_enter_pin">נא להכניס PIN</string>
     <string name="wrong_pin">שגיאה ב PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">חזור על PIN</string>
     <string name="pattern">דפוס</string>
     <string name="insert_pattern">הכנס דפוס</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">PINを入力</string>
     <string name="please_enter_pin">PINを入力してください</string>
     <string name="wrong_pin">PINに誤りがあります</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PINを再入力</string>
     <string name="pattern">パターン</string>
     <string name="insert_pattern">パターンを入力</string>

--- a/commons/src/main/res/values-ja/strings.xml
+++ b/commons/src/main/res/values-ja/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">PINを入力</string>
     <string name="please_enter_pin">PINを入力してください</string>
     <string name="wrong_pin">PINに誤りがあります</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PINを再入力</string>
     <string name="pattern">パターン</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">PIN 번호 입력</string>
     <string name="please_enter_pin">PIN 번호를 입력하세요.</string>
     <string name="wrong_pin">PIN 번호가 일치하지 않습니다.</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN 번호 확인</string>
     <string name="pattern">패턴</string>
     <string name="insert_pattern">패턴 입력</string>

--- a/commons/src/main/res/values-ko-rKR/strings.xml
+++ b/commons/src/main/res/values-ko-rKR/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">PIN 번호 입력</string>
     <string name="please_enter_pin">PIN 번호를 입력하세요.</string>
     <string name="wrong_pin">PIN 번호가 일치하지 않습니다.</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN 번호 확인</string>
     <string name="pattern">패턴</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Įvesti PIN kodą</string>
     <string name="please_enter_pin">Įveskite PIN kodą</string>
     <string name="wrong_pin">Neteisingas PIN kodas</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Pakartokite PIN kodą</string>
     <string name="pattern">Šablonas</string>

--- a/commons/src/main/res/values-lt/strings.xml
+++ b/commons/src/main/res/values-lt/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Įvesti PIN kodą</string>
     <string name="please_enter_pin">Įveskite PIN kodą</string>
     <string name="wrong_pin">Neteisingas PIN kodas</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Pakartokite PIN kodą</string>
     <string name="pattern">Šablonas</string>
     <string name="insert_pattern">Įveskite šabloną</string>

--- a/commons/src/main/res/values-ml/strings.xml
+++ b/commons/src/main/res/values-ml/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-ml/strings.xml
+++ b/commons/src/main/res/values-ml/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-nb-rNO/strings.xml
+++ b/commons/src/main/res/values-nb-rNO/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Oppfør PIN-kode</string>
     <string name="please_enter_pin">Oppfør en PIN-kode</string>
     <string name="wrong_pin">Feil PIN-kode</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Gjenta PIN-kode</string>
     <string name="pattern">Mønster</string>
     <string name="insert_pattern">Tegn mønster</string>

--- a/commons/src/main/res/values-nb-rNO/strings.xml
+++ b/commons/src/main/res/values-nb-rNO/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Oppfør PIN-kode</string>
     <string name="please_enter_pin">Oppfør en PIN-kode</string>
     <string name="wrong_pin">Feil PIN-kode</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Gjenta PIN-kode</string>
     <string name="pattern">Mønster</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">Pincode invoeren</string>
     <string name="please_enter_pin">Graag pincode invoeren</string>
     <string name="wrong_pin">Verkeerde pincode</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Pincode herhalen</string>
     <string name="pattern">Patroon</string>

--- a/commons/src/main/res/values-nl/strings.xml
+++ b/commons/src/main/res/values-nl/strings.xml
@@ -457,6 +457,7 @@
     <string name="enter_pin">Pincode invoeren</string>
     <string name="please_enter_pin">Graag pincode invoeren</string>
     <string name="wrong_pin">Verkeerde pincode</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Pincode herhalen</string>
     <string name="pattern">Patroon</string>
     <string name="insert_pattern">Patroon invoeren</string>

--- a/commons/src/main/res/values-pa-rPK/strings.xml
+++ b/commons/src/main/res/values-pa-rPK/strings.xml
@@ -461,6 +461,7 @@
     <string name="enter_pin">پین کوڈ پایو</string>
     <string name="please_enter_pin">تسیں کوئی پین کوڈ نہیں پاۓ گئے اے</string>
     <string name="wrong_pin">پین کوڈ نہیں درست اے</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">پین کوڈ فیر پایو</string>
     <string name="pattern">نمونہ</string>
     <string name="insert_pattern">نمونہ شامل کرو</string>

--- a/commons/src/main/res/values-pa-rPK/strings.xml
+++ b/commons/src/main/res/values-pa-rPK/strings.xml
@@ -461,6 +461,7 @@
     <string name="enter_pin">پین کوڈ پایو</string>
     <string name="please_enter_pin">تسیں کوئی پین کوڈ نہیں پاۓ گئے اے</string>
     <string name="wrong_pin">پین کوڈ نہیں درست اے</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">پین کوڈ فیر پایو</string>
     <string name="pattern">نمونہ</string>

--- a/commons/src/main/res/values-pa/strings.xml
+++ b/commons/src/main/res/values-pa/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-pa/strings.xml
+++ b/commons/src/main/res/values-pa/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -472,6 +472,7 @@
     <string name="enter_pin">Wprowadź PIN</string>
     <string name="please_enter_pin">Wprowadź PIN</string>
     <string name="wrong_pin">Nieprawidłowy PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Wprowadź PIN ponownie</string>
     <string name="pattern">Wzór</string>

--- a/commons/src/main/res/values-pl/strings.xml
+++ b/commons/src/main/res/values-pl/strings.xml
@@ -472,6 +472,7 @@
     <string name="enter_pin">Wprowadź PIN</string>
     <string name="please_enter_pin">Wprowadź PIN</string>
     <string name="wrong_pin">Nieprawidłowy PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Wprowadź PIN ponownie</string>
     <string name="pattern">Wzór</string>
     <string name="insert_pattern">Wprowadź wzór</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Digite o PIN</string>
     <string name="please_enter_pin">Favor digitar o PIN</string>
     <string name="wrong_pin">PIN incorreto</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Padrão</string>

--- a/commons/src/main/res/values-pt-rBR/strings.xml
+++ b/commons/src/main/res/values-pt-rBR/strings.xml
@@ -469,6 +469,7 @@
     <string name="enter_pin">Digite o PIN</string>
     <string name="please_enter_pin">Favor digitar o PIN</string>
     <string name="wrong_pin">PIN incorreto</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetir PIN</string>
     <string name="pattern">Padrão</string>
     <string name="insert_pattern">Inserir padrão</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -468,6 +468,7 @@
     <string name="enter_pin">Digite o PIN</string>
     <string name="please_enter_pin">Por favor digite o PIN</string>
     <string name="wrong_pin">PIN inválido</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repita o PIN</string>
     <string name="pattern">Padrão</string>

--- a/commons/src/main/res/values-pt/strings.xml
+++ b/commons/src/main/res/values-pt/strings.xml
@@ -468,6 +468,7 @@
     <string name="enter_pin">Digite o PIN</string>
     <string name="please_enter_pin">Por favor digite o PIN</string>
     <string name="wrong_pin">PIN inválido</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repita o PIN</string>
     <string name="pattern">Padrão</string>
     <string name="insert_pattern">Introduza o padrão</string>

--- a/commons/src/main/res/values-ro/strings.xml
+++ b/commons/src/main/res/values-ro/strings.xml
@@ -467,6 +467,7 @@
     <string name="enter_pin">Introduceţi PIN-ul</string>
     <string name="please_enter_pin">Vă rugăm introduceți un PIN</string>
     <string name="wrong_pin">PIN Greşit</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetaţi PIN-ul</string>
     <string name="pattern">Model</string>

--- a/commons/src/main/res/values-ro/strings.xml
+++ b/commons/src/main/res/values-ro/strings.xml
@@ -467,6 +467,7 @@
     <string name="enter_pin">Introduceţi PIN-ul</string>
     <string name="please_enter_pin">Vă rugăm introduceți un PIN</string>
     <string name="wrong_pin">PIN Greşit</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repetaţi PIN-ul</string>
     <string name="pattern">Model</string>
     <string name="insert_pattern">Introduceți modelul</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -475,6 +475,7 @@
     <string name="enter_pin">Ввод PIN-кода</string>
     <string name="please_enter_pin">Введите PIN-код</string>
     <string name="wrong_pin">Неправильный PIN-код</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повторите PIN-код</string>
     <string name="pattern">Графический ключ</string>

--- a/commons/src/main/res/values-ru/strings.xml
+++ b/commons/src/main/res/values-ru/strings.xml
@@ -475,6 +475,7 @@
     <string name="enter_pin">Ввод PIN-кода</string>
     <string name="please_enter_pin">Введите PIN-код</string>
     <string name="wrong_pin">Неправильный PIN-код</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повторите PIN-код</string>
     <string name="pattern">Графический ключ</string>
     <string name="insert_pattern">Установить ключ</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Zadajte PIN</string>
     <string name="please_enter_pin">Prosím zadajte PIN</string>
     <string name="wrong_pin">Nesprávny PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Zopakujte PIN</string>
     <string name="pattern">Vzor</string>
     <string name="insert_pattern">Zadajte vzor</string>

--- a/commons/src/main/res/values-sk/strings.xml
+++ b/commons/src/main/res/values-sk/strings.xml
@@ -470,6 +470,7 @@
     <string name="enter_pin">Zadajte PIN</string>
     <string name="please_enter_pin">Prosím zadajte PIN</string>
     <string name="wrong_pin">Nesprávny PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Zopakujte PIN</string>
     <string name="pattern">Vzor</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -476,6 +476,7 @@
     <string name="enter_pin">Vpišite PIN</string>
     <string name="please_enter_pin">Prosimo vpišite PIN</string>
     <string name="wrong_pin">Napačen PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ponovite PIN</string>
     <string name="pattern">Vzorec</string>

--- a/commons/src/main/res/values-sl/strings.xml
+++ b/commons/src/main/res/values-sl/strings.xml
@@ -476,6 +476,7 @@
     <string name="enter_pin">Vpišite PIN</string>
     <string name="please_enter_pin">Prosimo vpišite PIN</string>
     <string name="wrong_pin">Napačen PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Ponovite PIN</string>
     <string name="pattern">Vzorec</string>
     <string name="insert_pattern">Narišite vzorec</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -474,6 +474,7 @@
     <string name="enter_pin">Унесите ПИН</string>
     <string name="please_enter_pin">Молимо вас унесите ПИН</string>
     <string name="wrong_pin">Погрешан ПИН</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Поновите ПИН</string>
     <string name="pattern">Шаблон</string>

--- a/commons/src/main/res/values-sr/strings.xml
+++ b/commons/src/main/res/values-sr/strings.xml
@@ -474,6 +474,7 @@
     <string name="enter_pin">Унесите ПИН</string>
     <string name="please_enter_pin">Молимо вас унесите ПИН</string>
     <string name="wrong_pin">Погрешан ПИН</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Поновите ПИН</string>
     <string name="pattern">Шаблон</string>
     <string name="insert_pattern">Унесите шаблон</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -464,6 +464,7 @@
     <string name="enter_pin">Ange PIN-kod</string>
     <string name="please_enter_pin">Ange en PIN-kod</string>
     <string name="wrong_pin">Du har angett fel PIN-kod</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Upprepa PIN-kod</string>
     <string name="pattern">Mönster</string>

--- a/commons/src/main/res/values-sv/strings.xml
+++ b/commons/src/main/res/values-sv/strings.xml
@@ -464,6 +464,7 @@
     <string name="enter_pin">Ange PIN-kod</string>
     <string name="please_enter_pin">Ange en PIN-kod</string>
     <string name="wrong_pin">Du har angett fel PIN-kod</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Upprepa PIN-kod</string>
     <string name="pattern">Mönster</string>
     <string name="insert_pattern">Rita mönster</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">குறியீட்டெண்ணை உள்ளிடு</string>
     <string name="please_enter_pin">ஒரு குறியீட்டெண்ணை உள்ளிடவும்</string>
     <string name="wrong_pin">தவறான குறியீட்டெண்</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-ta/strings.xml
+++ b/commons/src/main/res/values-ta/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">குறியீட்டெண்ணை உள்ளிடு</string>
     <string name="please_enter_pin">ஒரு குறியீட்டெண்ணை உள்ளிடவும்</string>
     <string name="wrong_pin">தவறான குறியீட்டெண்</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-th/strings.xml
+++ b/commons/src/main/res/values-th/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values-th/strings.xml
+++ b/commons/src/main/res/values-th/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -461,6 +461,7 @@
     <string name="enter_pin">PIN\'i gir</string>
     <string name="please_enter_pin">Lütfen PIN\'i girin</string>
     <string name="wrong_pin">Yanlış PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN\'i tekrar gir</string>
     <string name="pattern">Desen</string>

--- a/commons/src/main/res/values-tr/strings.xml
+++ b/commons/src/main/res/values-tr/strings.xml
@@ -461,6 +461,7 @@
     <string name="enter_pin">PIN\'i gir</string>
     <string name="please_enter_pin">Lütfen PIN\'i girin</string>
     <string name="wrong_pin">Yanlış PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">PIN\'i tekrar gir</string>
     <string name="pattern">Desen</string>
     <string name="insert_pattern">Deseni çiz</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -473,6 +473,7 @@
     <string name="enter_pin">Введіть PIN</string>
     <string name="please_enter_pin">Будь ласка, введіть PIN</string>
     <string name="wrong_pin">Невірний PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повторіть PIN</string>
     <string name="pattern">Шаблон</string>
     <string name="insert_pattern">Вставити шаблон</string>

--- a/commons/src/main/res/values-uk/strings.xml
+++ b/commons/src/main/res/values-uk/strings.xml
@@ -473,6 +473,7 @@
     <string name="enter_pin">Введіть PIN</string>
     <string name="please_enter_pin">Будь ласка, введіть PIN</string>
     <string name="wrong_pin">Невірний PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Повторіть PIN</string>
     <string name="pattern">Шаблон</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Nhập PIN</string>
     <string name="please_enter_pin">Vui lòng nhập mã PIN</string>
     <string name="wrong_pin">PIN sai</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Lặp lại mã PIN</string>
     <string name="pattern">Mẫu hình</string>
     <string name="insert_pattern">Chèn mẫu hình</string>

--- a/commons/src/main/res/values-vi/strings.xml
+++ b/commons/src/main/res/values-vi/strings.xml
@@ -463,6 +463,7 @@
     <string name="enter_pin">Nhập PIN</string>
     <string name="please_enter_pin">Vui lòng nhập mã PIN</string>
     <string name="wrong_pin">PIN sai</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Lặp lại mã PIN</string>
     <string name="pattern">Mẫu hình</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -453,6 +453,7 @@
     <string name="enter_pin">输入密码</string>
     <string name="please_enter_pin">请输入密码</string>
     <string name="wrong_pin">密码错误</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">重复密码</string>
     <string name="pattern">图案</string>

--- a/commons/src/main/res/values-zh-rCN/strings.xml
+++ b/commons/src/main/res/values-zh-rCN/strings.xml
@@ -453,6 +453,7 @@
     <string name="enter_pin">输入密码</string>
     <string name="please_enter_pin">请输入密码</string>
     <string name="wrong_pin">密码错误</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">重复密码</string>
     <string name="pattern">图案</string>
     <string name="insert_pattern">绘制图案</string>

--- a/commons/src/main/res/values-zh-rHK/strings.xml
+++ b/commons/src/main/res/values-zh-rHK/strings.xml
@@ -455,6 +455,7 @@
     <string name="enter_pin">输入密码</string>
     <string name="please_enter_pin">请输入密码</string>
     <string name="wrong_pin">密码错误</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">重复密码</string>
     <string name="pattern">图案</string>
     <string name="insert_pattern">绘制图案</string>

--- a/commons/src/main/res/values-zh-rHK/strings.xml
+++ b/commons/src/main/res/values-zh-rHK/strings.xml
@@ -455,6 +455,7 @@
     <string name="enter_pin">输入密码</string>
     <string name="please_enter_pin">请输入密码</string>
     <string name="wrong_pin">密码错误</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">重复密码</string>
     <string name="pattern">图案</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -459,6 +459,7 @@
     <string name="enter_pin">輸入PIN碼</string>
     <string name="please_enter_pin">請輸入PIN碼</string>
     <string name="wrong_pin">PIN碼錯誤</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">再次輸入PIN碼</string>
     <string name="pattern">圖形</string>

--- a/commons/src/main/res/values-zh-rTW/strings.xml
+++ b/commons/src/main/res/values-zh-rTW/strings.xml
@@ -459,6 +459,7 @@
     <string name="enter_pin">輸入PIN碼</string>
     <string name="please_enter_pin">請輸入PIN碼</string>
     <string name="wrong_pin">PIN碼錯誤</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">再次輸入PIN碼</string>
     <string name="pattern">圖形</string>
     <string name="insert_pattern">畫出解鎖圖形</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="pin_must_be_4_digits_long">PIN must be at least 4 digits long</string>
     <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>

--- a/commons/src/main/res/values/strings.xml
+++ b/commons/src/main/res/values/strings.xml
@@ -489,6 +489,7 @@
     <string name="enter_pin">Enter PIN</string>
     <string name="please_enter_pin">Please enter a PIN</string>
     <string name="wrong_pin">Wrong PIN</string>
+    <string name="too_many_incorrect_attempts">Too many incorrect unlock attempts.\nTry again in %d seconds.</string>
     <string name="repeat_pin">Repeat PIN</string>
     <string name="pattern">Pattern</string>
     <string name="insert_pattern">Insert pattern</string>


### PR DESCRIPTION
### Changes and notes:
 - After 3 incorrect attempts, the user is locked out for 5 seconds. This doesn't distinguish between folder lock vs app lock. 3 incorrect attempts to unlock a folder will cause the whole app to be inaccessible as well. This is because lockin a folder doesn't make sense when app level lock is enabled plus we'll have to complicate things by handling retry count and lock-out time for everything separately.
 - Limit the minimum pin length to 4 digits. This is necessary because even with lockout, there are only 10 combinations one needs to try to break in if the user uses a single-digit PIN. This doesn't affect users already using a PIN shorter than 4 digits.
 -  Move the title to the center and add a lock icon.

### Screenshots:
<img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/e37a7558-dc03-4afa-b489-343dcfd2971a" width=264 />
<img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/1cb885a3-d7d8-4df8-b0d0-1dec1350275a" width=264 />
<img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/ed062b90-5547-4fda-b837-15a8c5aa4a49" width=264 />
