### PR TITLE
Improve password protection further

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/TextView.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/TextView.kt
@@ -4,11 +4,8 @@ import android.graphics.Paint
 import android.text.SpannableString
 import android.text.TextPaint
 import android.text.style.URLSpan
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
 import android.widget.TextView
 import androidx.annotation.StringRes
-import androidx.core.widget.doOnTextChanged
 
 val TextView.value: String get() = text.toString().trim()
 
@@ -35,16 +32,5 @@ fun TextView.setTextOrBeGone(@StringRes textRes: Int?) {
         this.text = context.getString(textRes)
     } else {
         beGone()
-    }
-}
-
-fun TextView.blink(count: Int = 3, duration: Long = 150L): Animation {
-    return AlphaAnimation(0.0f, 1.0f).apply {
-        this.duration = duration
-        startOffset = 20
-        repeatMode = Animation.REVERSE
-        repeatCount = count
-        startAnimation(this)
-        doOnTextChanged { _, _, _, _ -> cancel() }
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
@@ -10,7 +10,6 @@ import androidx.annotation.ColorInt
 import androidx.core.os.postDelayed
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.extensions.baseConfig
-import com.simplemobiletools.commons.extensions.blink
 import com.simplemobiletools.commons.extensions.countdown
 import com.simplemobiletools.commons.extensions.getProperTextColor
 import com.simplemobiletools.commons.helpers.DEFAULT_PASSWORD_COUNTDOWN
@@ -45,7 +44,6 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
             startCountdown()
         } else {
             updateTitle(context.getString(wrongTextRes), context.getColor(R.color.md_red))
-            titleTextView.blink()
             handler.postDelayed(delayInMillis = 1000) {
                 updateTitle(context.getString(defaultTextRes), context.getProperTextColor())
             }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/interfaces/BaseSecurityTab.kt
@@ -29,6 +29,8 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
     private val config = context.baseConfig
     private val handler = Handler(Looper.getMainLooper())
 
+    open fun onLockedOutChange(lockedOut: Boolean) {}
+
     fun isLockedOut() = requiredHash.isNotEmpty() && getCountdown() > 0
 
     fun onCorrectPassword() {
@@ -41,6 +43,7 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
     fun onIncorrectPassword() {
         config.passwordRetryCount += 1
         if (requiredHash.isNotEmpty() && shouldStartCountdown()) {
+            onLockedOutChange(lockedOut = true)
             startCountdown()
         } else {
             updateTitle(context.getString(wrongTextRes), context.getColor(R.color.md_red))
@@ -54,7 +57,7 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
         if (shouldStartCountdown()) {
             startCountdown()
         } else {
-            updateCountdown(0)
+            updateCountdownText(0)
         }
     }
 
@@ -93,14 +96,15 @@ abstract class BaseSecurityTab(context: Context, attrs: AttributeSet) : Relative
 
     private fun startCountdown() {
         getCountdown().countdown(intervalMillis = 1000L) { count ->
-            updateCountdown(count)
+            updateCountdownText(count)
             if (count == 0) {
                 resetCountdown()
+                onLockedOutChange(lockedOut = false)
             }
         }
     }
 
-    private fun updateCountdown(count: Int) {
+    private fun updateCountdownText(count: Int) {
         removeCallbacks()
         if (count > 0) {
             updateTitle(context.getString(R.string.too_many_incorrect_attempts, count), context.getColor(R.color.md_red))

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PatternTab.kt
@@ -76,6 +76,10 @@ class PatternTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(contex
         hashListener = listener
     }
 
+    override fun onLockedOutChange(lockedOut: Boolean) {
+        binding.patternLockView.isInputEnabled = !lockedOut
+    }
+
     private fun receivedHash(newHash: String) {
         if (isLockedOut()) {
             performHapticFeedback()

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
@@ -124,9 +124,6 @@ class PinTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(context, a
 
     private fun updatePinCode() {
         binding.pinLockCurrentPin.text = "*".repeat(pin.length)
-        if (computedHash.isNotEmpty() && computedHash == getHashedPin()) {
-            onCorrectPassword()
-        }
     }
 
     private fun getHashedPin(): String {

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/views/PinTab.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.commons.views
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.TextView
+import android.widget.Toast
 import androidx.biometric.auth.AuthPromptHost
 import com.simplemobiletools.commons.R
 import com.simplemobiletools.commons.databinding.TabPinBinding
@@ -86,12 +87,12 @@ class PinTab(context: Context, attrs: AttributeSet) : BaseSecurityTab(context, a
             val newHash = getHashedPin()
             when {
                 pin.isEmpty() -> {
-                    context.toast(R.string.please_enter_pin)
+                    context.toast(id = R.string.please_enter_pin, length = Toast.LENGTH_LONG)
                 }
 
                 computedHash.isEmpty() && pin.length < MINIMUM_PIN_LENGTH -> {
                     resetPin()
-                    context.toast(R.string.pin_must_be_4_digits_long)
+                    context.toast(id = R.string.pin_must_be_4_digits_long, length = Toast.LENGTH_LONG)
                 }
 
                 computedHash.isEmpty() -> {

--- a/commons/src/main/res/layout/tab_pattern.xml
+++ b/commons/src/main/res/layout/tab_pattern.xml
@@ -19,7 +19,11 @@
         android:layout_below="@id/pattern_lock_icon"
         android:layout_alignParentStart="true"
         android:layout_alignParentEnd="true"
-        android:padding="@dimen/activity_margin"
+        android:minLines="2"
+        android:paddingLeft="@dimen/activity_margin"
+        android:paddingTop="@dimen/activity_margin"
+        android:paddingRight="@dimen/activity_margin"
+        android:paddingBottom="@dimen/small_margin"
         android:text="@string/insert_pattern"
         android:textAlignment="center"
         android:textSize="@dimen/bigger_text_size" />

--- a/commons/src/main/res/layout/tab_pattern.xml
+++ b/commons/src/main/res/layout/tab_pattern.xml
@@ -6,10 +6,10 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/pattern_lock_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/medium_icon_size"
+        android:layout_height="@dimen/medium_icon_size"
         android:layout_centerHorizontal="true"
-        android:layout_marginTop="@dimen/normal_margin"
+        android:layout_marginTop="@dimen/activity_margin"
         android:src="@drawable/ic_lock_outlined_vector" />
 
     <com.simplemobiletools.commons.views.MyTextView
@@ -21,7 +21,8 @@
         android:layout_alignParentEnd="true"
         android:padding="@dimen/activity_margin"
         android:text="@string/insert_pattern"
-        android:textAlignment="center" />
+        android:textAlignment="center"
+        android:textSize="@dimen/bigger_text_size" />
 
     <com.andrognito.patternlockview.PatternLockView
         android:id="@+id/pattern_lock_view"

--- a/commons/src/main/res/layout/tab_pin.xml
+++ b/commons/src/main/res/layout/tab_pin.xml
@@ -7,8 +7,8 @@
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/pin_lock_icon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/medium_icon_size"
+        android:layout_height="@dimen/medium_icon_size"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="@dimen/activity_margin"
         android:src="@drawable/ic_lock_outlined_vector" />
@@ -26,7 +26,8 @@
         android:paddingRight="@dimen/activity_margin"
         android:paddingBottom="@dimen/small_margin"
         android:text="@string/enter_pin"
-        android:textAlignment="center" />
+        android:textAlignment="center"
+        android:textSize="@dimen/bigger_text_size" />
 
     <com.simplemobiletools.commons.views.MyTextView
         android:id="@+id/pin_lock_current_pin"

--- a/commons/src/main/res/values/dimens.xml
+++ b/commons/src/main/res/values/dimens.xml
@@ -25,6 +25,7 @@
     <dimen name="colorpicker_color_width">70dp</dimen>
 
     <dimen name="normal_icon_size">48dp</dimen>
+    <dimen name="medium_icon_size">32dp</dimen>
     <dimen name="fingerprint_icon_size">72dp</dimen>
     <dimen name="fab_size">56dp</dimen>
     <dimen name="secondary_fab_bottom_margin">76dp</dimen>


### PR DESCRIPTION
### Changes:
 - Removing blinking animation from error text.
 - Disable automatic unlock on the correct PIN.
 - Disable pattern input when the locked-out countdown is in progress (it won't provide any feedback on touch).
 - Increase the dialog's title and icon size. I used 32dp because 40dp and 48dp looked too big.
 - Show long error toasts.

### Before vs After:

<img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/d84f6194-d5fb-4250-89c6-bad5cae674a5" width=190 /> <img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/94e64c30-dd22-48e6-8011-a7bb9bcb85f6" width=190 />   <img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/a283d2d7-7b79-48dd-8a4d-17affe793a6b" width=190 /> <img src="https://github.com/SimpleMobileTools/Simple-Commons/assets/36371707/ff4e4d2a-f7c8-40d7-ae01-5d7c4574e199" width=190 />


