### PR TITLE
Wrap current ColorPickerDialog in compose version

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ColorPickerDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/ColorPickerDialog.kt
@@ -405,7 +405,7 @@ private fun Context.addRecentColor(color: Int) {
 
 @Composable
 @MyDevices
-private fun LineColorPickerAlertDialogPreview() {
+private fun ColorPickerAlertDialogPreview() {
     AppThemeSurface {
         ColorPickerAlertDialog(
             alertDialogState = rememberAlertDialogState(),

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/LineColorPickerDialog.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/dialogs/LineColorPickerDialog.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.commons.dialogs
 import android.content.Context
 import android.view.WindowManager
 import android.widget.FrameLayout
+import androidx.annotation.ColorInt
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -166,6 +167,7 @@ class LineColorPickerDialog(
 fun LineColorPickerAlertDialog(
     alertDialogState: AlertDialogState,
     modifier: Modifier = Modifier,
+    @ColorInt
     color: Int,
     isPrimaryColorPicker: Boolean,
     primaryColors: Int = R.array.md_primary_colors,

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
@@ -9,12 +9,12 @@ import com.simplemobiletools.commons.extensions.getInternalStoragePath
 import com.simplemobiletools.commons.extensions.getSDCardPath
 import com.simplemobiletools.commons.extensions.getSharedPrefs
 import com.simplemobiletools.commons.extensions.sharedPreferencesCallback
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterNotNull
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.LinkedList
 import java.util.Locale
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterNotNull
 import kotlin.reflect.KProperty0
 
 open class BaseConfig(val context: Context) {
@@ -498,6 +498,8 @@ open class BaseConfig(val context: Context) {
             return LinkedList(prefs.getString(COLOR_PICKER_RECENT_COLORS, null)?.lines()?.map { it.toInt() } ?: defaultList)
         }
         set(recentColors) = prefs.edit().putString(COLOR_PICKER_RECENT_COLORS, recentColors.joinToString(separator = "\n")).apply()
+
+    val colorPickerRecentColorsFlow = ::colorPickerRecentColors.asFlowNonNull()
 
     var ignoredContactSources: HashSet<String>
         get() = prefs.getStringSet(IGNORED_CONTACT_SOURCES, hashSetOf(".")) as HashSet

--- a/samples/src/main/kotlin/com/simplemobiletools/commons/samples/activities/TestDialogActivity.kt
+++ b/samples/src/main/kotlin/com/simplemobiletools/commons/samples/activities/TestDialogActivity.kt
@@ -47,6 +47,7 @@ class TestDialogActivity : ComponentActivity() {
                     ShowButton(getFeatureLockedAlertDialogState(), text = "Feature Locked")
                     ShowButton(getPurchaseThankYouAlertDialogState(), text = "Purchase thank you")
                     ShowButton(getLineColorPickerAlertDialogState(), text = "Line color picker")
+                    ShowButton(getColorPickerAlertDialogState(), text = "Color picker")
                     ShowButton(getCallConfirmationAlertDialogState(), text = "Call confirmation")
                     ShowButton(getChangeDateTimeFormatAlertDialogState(), text = "Change date time")
                     ShowButton(getRateStarsAlertDialogState(), text = "Rate us")
@@ -156,6 +157,21 @@ class TestDialogActivity : ComponentActivity() {
                     Log.d("getLineColorPickerAlertDialogState", "wasPositivePressed=$wasPositivePressed color=${color.toHex()}")
                 }, onActiveColorChange = { color ->
                     Log.d("getLineColorPickerAlertDialogState", "onActiveColorChange=${color.toHex()}")
+                })
+        }
+    }
+
+    @Composable
+    private fun getColorPickerAlertDialogState() = rememberAlertDialogState().apply {
+        DialogMember {
+            ColorPickerAlertDialog(
+                alertDialogState = this,
+                color = config.customTextColor,
+                removeDimmedBackground = true,
+                onButtonPressed = { wasPositivePressed, color ->
+                    Log.d("getColorPickerAlertDialogState", "wasPositivePressed=$wasPositivePressed color=${color.toHex()}")
+                }, onActiveColorChange = { color ->
+                    Log.d("getColorPickerAlertDialogState", "onActiveColorChange=${color.toHex()}")
                 })
         }
     }


### PR DESCRIPTION
Wrapping current `ColorPickerDialog`, similar to `LineColorPickerDialog`, as agreed in #1858 