### PR TITLE
Add separate `AppTheme` composable without any surface

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/compose/theme/AppTheme.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/compose/theme/AppTheme.kt
@@ -37,6 +37,7 @@ fun AppTheme(
     TransparentSystemBars()
     Theme(theme = currentTheme) {
         content()
+        OnContentDisplayed()
     }
 }
 
@@ -48,7 +49,6 @@ fun AppThemeSurface(
     AppTheme {
         Surface(modifier = modifier.fillMaxSize()) {
             content()
-            OnContentDisplayed()
         }
     }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/compose/theme/AppTheme.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/compose/theme/AppTheme.kt
@@ -14,8 +14,7 @@ import com.simplemobiletools.commons.compose.theme.model.Theme
 import com.simplemobiletools.commons.compose.theme.model.Theme.Companion.systemDefaultMaterialYou
 
 @Composable
-fun AppThemeSurface(
-    modifier: Modifier = Modifier,
+fun AppTheme(
     content: @Composable () -> Unit,
 ) {
     val view = LocalView.current
@@ -37,6 +36,16 @@ fun AppThemeSurface(
     }
     TransparentSystemBars()
     Theme(theme = currentTheme) {
+        content()
+    }
+}
+
+@Composable
+fun AppThemeSurface(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    AppTheme {
         Surface(modifier = modifier.fillMaxSize()) {
             content()
             OnContentDisplayed()


### PR DESCRIPTION
This is needed for screens like widget configuration, which have fully transparent backgrounds