### PR TITLE
Add `sendOnCollect` flag to `sharedPreferencesCallback` for consistent values flow

### DIFF
--- a/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/SharedPreferencesProducerExtensions.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/extensions/SharedPreferencesProducerExtensions.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.callbackFlow
 
 context (SharedPreferences)
 fun <T> sharedPreferencesCallback(
+    sendOnCollect: Boolean = false,
     value: () -> T?,
 ): Flow<T?> = callbackFlow {
     val sharedPreferencesListener =
@@ -14,6 +15,9 @@ fun <T> sharedPreferencesCallback(
             trySend(value())
         }
 
+    if (sendOnCollect) {
+        trySend(value())
+    }
     registerOnSharedPreferenceChangeListener(sharedPreferencesListener)
     awaitClose { unregisterOnSharedPreferenceChangeListener(sharedPreferencesListener) }
 }

--- a/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
+++ b/commons/src/main/kotlin/com/simplemobiletools/commons/helpers/BaseConfig.kt
@@ -609,7 +609,7 @@ open class BaseConfig(val context: Context) {
         get() = prefs.getLong(PASSWORD_COUNTDOWN_START_MS, 0L)
         set(passwordCountdownStartMs) = prefs.edit().putLong(PASSWORD_COUNTDOWN_START_MS, passwordCountdownStartMs).apply()
 
-    protected fun <T> KProperty0<T>.asFlow(): Flow<T?> = prefs.run { sharedPreferencesCallback { this@asFlow.get() } }
+    protected fun <T> KProperty0<T>.asFlow(emitOnCollect: Boolean = false): Flow<T?> = prefs.run { sharedPreferencesCallback(sendOnCollect = emitOnCollect) { this@asFlow.get() } }
 
-    protected fun <T> KProperty0<T>.asFlowNonNull(): Flow<T> = asFlow().filterNotNull()
+    protected fun <T> KProperty0<T>.asFlowNonNull(emitOnCollect: Boolean = false): Flow<T> = asFlow(emitOnCollect).filterNotNull()
 }


### PR DESCRIPTION
@FunkyMuse this is related to https://github.com/SimpleMobileTools/Simple-Flashlight/pull/213

I tested it in this sample app by making changes on `TestDialogActivity` and checking if they are reflected on `MainActivity`. They weren't reflected previously, but with this approach they are (only when `sendOnCollect` is true of course).